### PR TITLE
Master volume slider

### DIFF
--- a/js/5etools-main.js
+++ b/js/5etools-main.js
@@ -1006,6 +1006,30 @@ const betteR205etools = function () {
 			$("a#import-backgrounds-load").on(window.mousedowntype, () => d20plus.backgrounds.button());
 			$("a#import-optionalfeatures-load").on(window.mousedowntype, () => d20plus.optionalfeatures.button());
 			$("select#import-mode-select").on("change", () => d20plus.importer.importModeSwitch());
+			const changeTrackVolume = (trackId, value) => {
+				const track = d20plus.jukebox.getTrackById(trackId);
+				if (track && value) {
+					track.changeVolume(value);
+				}
+			};
+			$(`<div id="masterVolume" style="margin:10px;display:inline-block;width:80%;"></div>`)
+			.insertAfter("#jukeboxwhatsplaying").slider({
+				slide: (e, ui) => {
+					if ($("#masterVolumeEnabled").prop("checked")) {
+						window.d20.jukebox.lastFolderStructure.forEach(playlist => {
+							// The track is outside a playlist
+							if (!playlist.i) {
+								changeTrackVolume(playlist, ui.value);
+							} else {
+								playlist.i.forEach(trackId => changeTrackVolume(trackId, ui.value))
+							}
+						});
+					}
+				},
+				value: 50,
+			});
+			$("<h4>Master Volume</h4>").insertAfter("#jukeboxwhatsplaying").css("margin-left", "10px");
+			$(`<input type="checkbox" id="masterVolumeEnabled" style="position:relative;top:-11px;" title="Enable this to change the volume of all the tracks at the same time"/>`).insertAfter("#masterVolume").tooltip();
 		} else {
 			// player-only HTML if required
 		}


### PR DESCRIPTION
Since you can import whole playlists from JSON, it gets tedious to change the volume of 50+ tracks if all of them need to be turned up or down. This change introduces a mater volume slider on top of the
playlists, that can be enabled with a checkbox next to it. When you change the master volume slider, the volume for all the tracks changes accordingly.

At some point this could be changed to work like an actual master volume control, where it would keep the individual values of the tracks, but take the master volume slider as a modifier.