### PR TITLE
Remote libre audio track tab

### DIFF
--- a/js/5etools-main.js
+++ b/js/5etools-main.js
@@ -1019,6 +1019,9 @@ const betteR205etoolsMain = function () {
 			$wrprControls.append(altBindButton);
 		}
 		$("#journal btn#bind-drop-locations").on(window.mousedowntype, d20plus.bindDropLocations);
+
+		// Better20 jukebox tab
+		d20plus.remoteLibre.init();
 	};
 
 	d20plus.updateDifficulty = function () {

--- a/js/base-remote-libre.js
+++ b/js/base-remote-libre.js
@@ -1,0 +1,98 @@
+function remoteLibre() {
+	d20plus.remoteLibre = {
+		getRemotePlaylists() {
+            return fetch('https://api.github.com/repos/DMsGuild201/Roll20_resources/contents/playlist')
+            .then(response => response.json())
+            .then(data => {
+                const promises = data.map(file => d20plus.remoteLibre.downloadPlaylist(file.download_url));
+                return Promise.all(promises).then(res => d20plus.remoteLibre.processRemotePlaylists(res))
+            })
+            .catch(error => console.error(error))
+        },
+
+        downloadPlaylist(url) {
+            return fetch(url)
+            .then(response => response.json())
+            .catch(error => console.error(error))
+        },
+        
+        processRemotePlaylists(imports) {
+            return $.map(imports.filter(p=>!!p), entry => {
+                return $.map(entry.playlists, playlist => playlist.songs)
+            }).filter(track => track.source === "My Audio")
+        },
+        
+        drawRemoteLibreResults(tracks) {
+            return tracks.map((t, i) => `
+                <p style="margin-top:15px">${t.title}</p>
+                <div class="br20-result" style="display: flex">
+                    <audio class="audio" controls preload="none" style="flex: 35" src="${t.track_id}"></audio>
+                    
+                    <button class="remote-track btn" data-id=${i} style="margin-top:auto;margin-bottom:auto;flex:1;font-size:15px;margin-left:10px;">
+                        <span class="pictos">&amp;</span>
+                    </button>
+                </div>
+            `);
+        },
+        
+        drawJukeBoxTab(tracks) {
+            const trackHtml = d20plus.remoteLibre.drawRemoteLibreResults(tracks);
+            return `
+            <div class="betteR20 tab-pane" style="display: none;">
+                <div class="row-fluid">
+                    <div class="span12">
+                        <h3 style="margin-top: 6px; margin-bottom: 10px; text-align:initial;">Search for:</h3>
+                        <input id="remoteLibreSearch" type="text" placeholder="Begin typing to choose tracks by title..." style="width: 100%;">
+                        <div id="remoteLibreResults">
+                            ${trackHtml.join("")}
+                        </div>
+                    </div>
+                </div>
+            </div>`
+        },
+
+        wireTrackButtons() {
+            $(".remote-track.btn").click((e) => {
+                const id = $(e.currentTarget).data().id;
+                d20plus.jukebox.createTrack(d20plus.remoteLibre.filteredResults[id]);
+            });
+        },
+
+        init() {
+            d20plus.remoteLibre.jukeboxInjected = false;
+            d20plus.remoteLibre.remoteLibreTracks = {};
+            d20plus.remoteLibre.filteredResults = {};
+
+            d20plus.remoteLibre.getRemotePlaylists().then((tracks) => {
+                d20plus.remoteLibre.remoteLibreTracks = tracks;
+                d20plus.remoteLibre.filteredResults = tracks;
+            });
+
+            $("#addjukebox").click(() => {
+                if (!d20plus.remoteLibre.jukeboxInjected) {
+                    setTimeout(() => {
+                        const html = d20plus.remoteLibre.drawJukeBoxTab(d20plus.remoteLibre.filteredResults);
+                        $(".nav.nav-tabs").append(`<li><a data-tab="betteR20" href="javascript:void(0);">BetteR20</a></li>`);
+                        $(".tab-content").append(html)
+                        d20plus.remoteLibre.wireTrackButtons();
+                        $("#remoteLibreSearch").bind("paste keyup", function() {
+                            if ($(this).val()) {
+                                d20plus.remoteLibre.filteredResults = d20plus.remoteLibre.remoteLibreTracks.filter(t => t.title.toLowerCase().indexOf($(this).val()) >= 0);
+                            } else {
+                                d20plus.remoteLibre.filteredResults = d20plus.remoteLibre.remoteLibreTracks;
+                            }
+                            const results = d20plus.remoteLibre.drawRemoteLibreResults(d20plus.remoteLibre.filteredResults);
+                            $("#remoteLibreResults").html(results);
+                            d20plus.remoteLibre.wireTrackButtons();
+                        });
+                        // this needs to be moved
+                        d20plus.remoteLibre.jukeboxInjected = true;
+                    }, 100)
+                }
+            });
+        },
+
+    };
+}
+
+SCRIPT_EXTENSIONS.push(remoteLibre);

--- a/node/build-scripts.js
+++ b/node/build-scripts.js
@@ -105,6 +105,7 @@ const SCRIPTS = {
 			"base-mod",
 			"base-template",
 			"base-emoji",
+			"base-remote-libre",
 
 			"5etools-bootstrap",
 			"5etools-main",


### PR DESCRIPTION
This adds a new tab in the "Add Tracks" modal that takes the playlist JSONs from DMsGuild201, filters all the tracks that are marked as My Audio and creates a list of importable tracks. Kind of like a crappier audio version of the awesome art repo. Right now it's useless if you want to import a whole playlist, but for finding tracks that have already been uploaded using libre audio, this should help.