### PR TITLE
Fix/restore foreground with vision tokens

### DIFF
--- a/js/base-mod.js
+++ b/js/base-mod.js
@@ -932,15 +932,15 @@ function d20plusMod() {
 					r && d20.dyn_fog.ready() ? r = i._model.get("has_bright_light_vision") || i._model.get("has_low_light_vision") || i._model.get("has_night_vision") : r && (r = i._model.get("light_hassight")),
 					// BEGIN MOD
 					// We don't draw immediately the token. Instead we check it "to_render"
-					o && (!o || n && r) || (to_render = true) ,
-						i.renderingInGroup = null
+					o && (!o || n && r) || (to_render = true)
 					if (to_render) {
 						// For the token checked "to_render", we draw them if
 						// there isn't a foreground layer for the map or
 						// is a first render (with a foreground)
 						// is everything but an object
 						if ( no_foreground_layer || current_render_has_foreground || a != 'objects' ) {
-						 this._draw(t, i)
+						 this._draw(t, i) ,
+	 					 i.renderingInGroup = null
 						}
 					}
 					// END MOD

--- a/js/base-mod.js
+++ b/js/base-mod.js
@@ -846,7 +846,7 @@ function d20plusMod() {
 		// BEGIN MOD
 		// Here we get the layers and look if there's a foreground in the current map
 		let layers = d20.engine.canvas._objects.map(it => it.model?.get("layer") || window.currentEditingLayer)
-		let no_foreground_layer = false
+		let no_foreground_layer = true
 		layers.forEach((l) => {
 			if (l == 'foreground') {
 				no_foreground_layer = false


### PR DESCRIPTION
Reenable overlaying of foreground when udl is enabled

Known issues: if foreground layer has something in it, the tokens that have vision 0ft controlled by players are not over the light anymore (i.e. all the player view is dark) 
Workaround: assign a darkvision of 0.5 ft to every player token 