### PR TITLE
Fix applying status icon numbers

### DIFF
--- a/js/base-mod.js
+++ b/js/base-mod.js
@@ -740,6 +740,7 @@ function d20plusMod() {
 		}),
 			$(document).on("keypress.statusnum", function (t) {
 				// BEGIN MOD // TODO see if this clashes with keyboard shortcuts
+				var currentcontexttarget = d20.engine.selected()[0];
 				if ("dead" !== a && currentcontexttarget) {
 					// END MOD
 					var n = String.fromCharCode(t.which)


### PR DESCRIPTION
Assigns "currentcontexttarget", left unassigned before, to the first selected element. 
In cases where the hoverable status select menu is open, there should only ever be one element in the selected array, so this should target the correct one.