### PR TITLE
list class on tce spell import

### DIFF
--- a/js/5etools-spells.js
+++ b/js/5etools-spells.js
@@ -15,7 +15,7 @@ function d20plusSpells () {
 	d20plus.spells._listIndexConverter = (sp) => {
 		return {
 			name: sp.name.toLowerCase(),
-			class: ((sp.classes || {}).fromClassList || (it.classes || {}).fromClassListVariant || []).map(c => c.name.toLowerCase()),
+			class: ((sp.classes || {}).fromClassList || (sp.classes || {}).fromClassListVariant || []).map(c => c.name.toLowerCase()),
 			level: Parser.spLevelToFull(sp.level).toLowerCase(),
 			source: Parser.sourceJsonToAbv(sp.source).toLowerCase()
 		};

--- a/js/5etools-spells.js
+++ b/js/5etools-spells.js
@@ -9,13 +9,13 @@ function d20plusSpells () {
 	d20plus.spells._listCols = ["name", "class", "level", "source"];
 	d20plus.spells._listItemBuilder = (it) => `
 		<span class="name col-4" title="name">${it.name}</span>
-		<span class="class col-3" title="class">${((it.classes || {}).fromClassList || []).map(c => `CLS[${c.name}]`).join(", ")}</span>
+		<span class="class col-3" title="class">${((it.classes || {}).fromClassList || (it.classes || {}).fromClassListVariant || []).map(c => `CLS[${c.name}]`).join(", ")}</span>
 		<span class="level col-3" title="level">LVL[${Parser.spLevelToFull(it.level)}]</span>
 		<span title="source [Full source name is ${Parser.sourceJsonToFull(it.source)}]" class="source col-2">SRC[${Parser.sourceJsonToAbv(it.source)}]</span>`;
 	d20plus.spells._listIndexConverter = (sp) => {
 		return {
 			name: sp.name.toLowerCase(),
-			class: ((sp.classes || {}).fromClassList || []).map(c => c.name.toLowerCase()),
+			class: ((sp.classes || {}).fromClassList || (it.classes || {}).fromClassListVariant || []).map(c => c.name.toLowerCase()),
 			level: Parser.spLevelToFull(sp.level).toLowerCase(),
 			source: Parser.sourceJsonToAbv(sp.source).toLowerCase()
 		};


### PR DESCRIPTION
Made it so when you import spells, optional/varient classes show up. This is especially helpful for TCE spells, where most of them don't display class otherwise.