### PR TITLE
Update Avatar fixer default URLs

### DIFF
--- a/js/base-tool.js
+++ b/js/base-tool.js
@@ -570,8 +570,8 @@ function baseTool() {
 				<div id="d20plus-avatar-fixer" title="Better20 - Avatar Fixer">
 				<p><b>Warning:</b> this thing doesn't really work.</p>
 				<p>Current URLs (view only): <select class="view-only"></select></p>
-				<p><label>Replace:<br><input name="search" value="https://5etools.com/"></label></p>
-				<p><label>With:<br><input name="replace" value="https://thegiddylimit.github.io/"></label></p>
+				<p><label>Replace:<br><input name="search" value="https://5e.tools/"></label></p>
+				<p><label>With:<br><input name="replace" value="https://5etools-mirror-1.github.io/"></label></p>
 				<p><button class="btn">Go!</button></p>
 				</div>
 				`,


### PR DESCRIPTION
I'm tired of telling people to change them, especially the default `Search:`