### PR TITLE
Convert version checking and downloading to use github.

### DIFF
--- a/js/5etools-bootstrap.js
+++ b/js/5etools-bootstrap.js
@@ -6,7 +6,7 @@ const betteR205etools = function () {
 			d20plus.ut.log("Init (v" + d20plus.version + ")");
 			d20plus.ut.showLoadingMessage(scriptName);
 
-			d20plus.ut.checkVersion("5etools");
+			d20plus.ut.checkVersion();
 			d20plus.settingsHtmlHeader = `<hr><h3>betteR20-5etools v${d20plus.version}</h3>`;
 
 			d20plus.template.swapTemplates();

--- a/js/base-util.js
+++ b/js/base-util.js
@@ -40,7 +40,7 @@ function baseUtil () {
 		d20.tddice.canRoll3D = () => false;
 	};
 
-	d20plus.ut.checkVersion = (scriptType) => {
+	d20plus.ut.checkVersion = () => {
 		d20plus.ut.log("Checking current version");
 
 		function cmpVersions (a, b) {
@@ -58,24 +58,18 @@ function baseUtil () {
 			return segmentsA.length - segmentsB.length;
 		}
 
-		let scriptUrl;
-		switch (scriptType) {
-			case "core": scriptType = `https://get.5e.tools/script/betteR20-core.user.js${d20plus.ut.getAntiCacheSuffix()}`; break;
-			case "5etools": scriptType = `https://get.5e.tools/script/betteR20-5etools.user.js${d20plus.ut.getAntiCacheSuffix()}`; break;
-			default: scriptUrl = "https://get.5e.tools/"; break;
-		}
-
 		$.ajax({
-			url: `https://get.5e.tools`,
+			url: `https://github.com/TheGiddyLimit/betterR20/blob/development/dist/betteR20-version?raw=true`,
 			success: (data) => {
-				const m = /<!--\s*(\d+\.\d+\.\d+)\s*-->/.exec(data);
-				if (m) {
+				if (data) {
 					const curr = d20plus.version;
-					const avail = m[1];
+					const avail = data;
 					const cmp = cmpVersions(curr, avail);
 					if (cmp < 0) {
 						setTimeout(() => {
-							d20plus.ut.sendHackerChat(`A newer version of betteR20 is available. Get ${avail} <a href="https://get.5e.tools/">here</a>. For help and support, see our <a href="https://wiki.5e.tools/index.php/BetteR20_FAQ">wiki</a> or join our <a href="https://discord.gg/nGvRCDs">Discord</a>.`);
+							const rawToolsInstallUrl = "https://github.com/TheGiddyLimit/betterR20/blob/development/dist/betteR20-5etools.user.js?raw=true";
+							const rawCoreInstallUrl = "https://github.com/TheGiddyLimit/betterR20/blob/development/dist/betteR20-core.user.js?raw=true";
+							d20plus.ut.sendHackerChat(`A newer version of betteR20 is available. Get ${avail} <a href="${rawToolsInstallUrl}">5etools</a> OR <a href="${rawCoreInstallUrl}">core</a>. For help and support, see our <a href="https://wiki.5e.tools/index.php/BetteR20_FAQ">wiki</a> or join our <a href="https://discord.gg/nGvRCDs">Discord</a>.`);
 						}, 1000);
 					}
 				}

--- a/js/core-bootstrap.js
+++ b/js/core-bootstrap.js
@@ -4,7 +4,7 @@ const betteR20Core = function () {
 		try {
 			d20plus.ut.log("Init (v" + d20plus.version + ")");
 			d20plus.ut.showLoadingMessage(scriptName);
-			d20plus.ut.checkVersion("core");
+			d20plus.ut.checkVersion();
 			d20plus.settingsHtmlHeader = `<hr><h3>betteR20-core v${d20plus.version}</h3>`;
 
 			d20plus.template.swapTemplates();

--- a/node/build-scripts.js
+++ b/node/build-scripts.js
@@ -238,4 +238,6 @@ Object.entries(SCRIPTS).forEach(([k, v]) => {
 	fs.writeFileSync(filename, fullScript);
 });
 
+fs.writeFileSync(`${BUILD_DIR}/betteR20-version`, `${SCRIPT_VERSION}`);
+
 console.log(`v${SCRIPT_VERSION}: Build completed at ${(new Date()).toJSON().slice(11, 19)}`);


### PR DESCRIPTION
Convert version checking and downloading to use github.
Should make the tool more robust in case of site outages ... assuming github doesn't go down.