### PR TITLE
Missing slash with default settings caused incorrect url when importing

### DIFF
--- a/js/5etools-main.js
+++ b/js/5etools-main.js
@@ -266,7 +266,7 @@ const betteR205etoolsMain = function () {
 		"_name": "Import",
 		"baseSiteUrl": {
 			"name": "5e Tools Website (reload to apply changes)",
-			"default": "https://5etools-mirror-1.github.io",
+			"default": "https://5etools-mirror-1.github.io/",
 			"_type": "String",
 			"_player": true
 		},


### PR DESCRIPTION
Due to the missing slash there, the import url would be set as `https://5etools-mirror-1.github.iodata/....`.

![image](https://user-images.githubusercontent.com/325499/136659614-0e637c9f-490e-4ee0-b789-319c7ec23422.png)
