### PR TITLE
Allows a user to import monsters from beastiary-sublist-data.json

### DIFF
--- a/js/5etools-monsters.js
+++ b/js/5etools-monsters.js
@@ -226,7 +226,7 @@ function d20plusMonsters () {
 		const data = await DataUtil.pUserUpload();
 
 		// Get the relevant information from the JSON
-		const monsterdata = data.jsons[0].monster;
+		const monsterdata = data.jsons[0].monster ? data.jsons[0].monster : data.jsons[0];
 
 		if (monsterdata) {
 			// Create an import list from the JSON


### PR DESCRIPTION
Allow a user to import monsters from a "beastiary-sublist-data.json" file that is generated in 5e.tools to Roll20 without having to modify the JSON first.

1. Go to 5e.tools beastiary
2. Add some monsters to the encounter builder
3. Right Click on encounter builder and select "Download JSON Data"
4. Go to Roll 20 Game
5. Import Monsters From file
6. Select Downloaded JSON from 5e Tools
7. Imports Monster
![betterr20PRGif](https://user-images.githubusercontent.com/4760418/141825486-02b5889c-b7f3-47e1-9575-39b4696a09cc.gif)
s