### PR TITLE
fixed roll20 breaking settings buttons

### DIFF
--- a/js/5etools-main.js
+++ b/js/5etools-main.js
@@ -887,13 +887,13 @@ const betteR205etoolsMain = function () {
 			$ptAdventures.find(`.Vetools-module-tool-open`).click(() => d20plus.tool.get("MODULES").openFn());
 			$wrpSettings.append(d20plus.settingsHtmlPtImportFooter);
 
-			$("#mysettings > .content a#button-monsters-load").on(window.mousedowntype, d20plus.monsters.button);
-			$("#mysettings > .content a#button-monsters-load-all").on(window.mousedowntype, d20plus.monsters.buttonAll);
-			$("#mysettings > .content a#button-monsters-load-file").on(window.mousedowntype, d20plus.monsters.buttonFile);
-			$("#mysettings > .content a#import-objects-load").on(window.mousedowntype, d20plus.objects.button);
-			$("#mysettings > .content a#button-adventures-load").on(window.mousedowntype, d20plus.adventures.button);
+			$("#button-monsters-load").on(window.mousedowntype, d20plus.monsters.button);
+			$("#button-monsters-load-all").on(window.mousedowntype, d20plus.monsters.buttonAll);
+			$("#button-monsters-load-file").on(window.mousedowntype, d20plus.monsters.buttonFile);
+			$("#import-objects-load").on(window.mousedowntype, d20plus.objects.button);
+			$("#button-adventures-load").on(window.mousedowntype, d20plus.adventures.button);
 
-			$("#mysettings > .content a#bind-drop-locations").on(window.mousedowntype, d20plus.bindDropLocations);
+			$("#bind-drop-locations").on(window.mousedowntype, d20plus.bindDropLocations);
 			$("#initiativewindow .characterlist").before(d20plus.initiativeHeaders);
 
 			d20plus.setTurnOrderTemplate();

--- a/js/base-ui.js
+++ b/js/base-ui.js
@@ -6,7 +6,7 @@ function baseUi () {
 		const $body = $("body");
 
 		const $wrpSettings = $(`<div id="betteR20-settings"/>`);
-		$("#mysettings > .content").children("hr").first().before($wrpSettings);
+		$("#settings-accordion").children(".panel.panel-default").first().before($wrpSettings);
 
 		$wrpSettings.append(d20plus.settingsHtmlHeader);
 		$body.append(d20plus.configEditorHTML);
@@ -63,8 +63,9 @@ function baseUi () {
 	d20plus.ui.addHtmlFooter = () => {
 		const $wrpSettings = $(`#betteR20-settings`);
 		$wrpSettings.append(d20plus.settingsHtmlPtFooter);
+		$wrpSettings.css("margin","5px");
 
-		$("#mysettings > .content a#button-edit-config").on(window.mousedowntype, d20plus.cfg.openConfigEditor);
+		$("#button-edit-config").on(window.mousedowntype, d20plus.cfg.openConfigEditor);
 		d20plus.tool.addTools();
 	};
 


### PR DESCRIPTION
Fixed roll20 changing some elements and causing buttons to dispensary by rearranging jquery. This is a pretty bare bones fix, but can be improved upon.