### PR TITLE
fixed importing maps with the module importer

### DIFF
--- a/js/5etools-main.js
+++ b/js/5etools-main.js
@@ -232,6 +232,10 @@ const betteR205etoolsMain = function () {
 		d20plus.ut.log("Bind Graphics");
 		try {
 			if (page.get("archived") === false) {
+				// Roll20 creates thegraphics and similar variables on page load, not page creation
+				if (!page.thegraphics) {
+					page.fullyLoadPage();
+				}
 				page.thegraphics.on("add", function (e) {
 					let character = e.character;
 					if (character) {

--- a/js/base-tool-module.js
+++ b/js/base-tool-module.js
@@ -369,7 +369,6 @@ function baseToolModule () {
 								switch (prop) {
 									case "maps": {
 										const map = d20.Campaign.pages.create(entry.attributes);
-										map.fullyLoadPage();
 										entry.graphics.forEach(it => map.thegraphics.create(it));
 										entry.paths.forEach(it => map.thepaths.create(it));
 										entry.text.forEach(it => map.thetexts.create(it));

--- a/js/base-tool-module.js
+++ b/js/base-tool-module.js
@@ -369,6 +369,7 @@ function baseToolModule () {
 								switch (prop) {
 									case "maps": {
 										const map = d20.Campaign.pages.create(entry.attributes);
+										map.fullyLoadPage();
 										entry.graphics.forEach(it => map.thegraphics.create(it));
 										entry.paths.forEach(it => map.thepaths.create(it));
 										entry.text.forEach(it => map.thetexts.create(it));


### PR DESCRIPTION
Roll20 broke maps in the module importer so this is a quick fix for them. There is some weirdness with bindGraphics being called too early though.