### PR TITLE
Added lair actions and regional effects to monster import

### DIFF
--- a/js/5etools-bootstrap.js
+++ b/js/5etools-bootstrap.js
@@ -35,6 +35,8 @@ const betteR205etools = function () {
 
 			if (window.is_gm) await d20plus.art.pLoadArt();
 
+			if (window.is_gm) await d20plus.monsters.pLoadLegGroups();
+
 			d20plus.bindDropLocations();
 			d20plus.ui.addHtmlHeader();
 			d20plus.addCustomHTML();

--- a/js/5etools-monsters.js
+++ b/js/5etools-monsters.js
@@ -153,6 +153,15 @@ function d20plusMonsters () {
 			}
 		});
 	};
+	
+	/**
+	 * Preload a legendary group map so that monsters with legendary groups
+	 * (lair actions and regional effects) can get their data more efficiently
+	 */
+	d20plus.monsters.pLoadLegGroups = async function () {
+		await DataUtil.monster.pPreloadMeta();
+	}
+
 	// Import Monsters button was clicked
 	d20plus.monsters.button = function () {
 		const url = $("#import-monster-url").val();
@@ -1339,6 +1348,19 @@ function d20plusMonsters () {
 								}
 							}
 
+							// Load lair actions and regional effects
+							if (data.legendaryGroup) {
+								const legGroup = DataUtil.monster.getMetaGroup(data);
+								if (legGroup) {
+									if (legGroup.lairActions) {
+										renderFluff += renderer.render({entries: legGroup.lairActions, name: "Lair Actions"}, depth = 2);
+									}
+									if (legGroup.regionalEffects) {
+										renderFluff += renderer.render({entries: legGroup.regionalEffects, name: "Regional Effects"}, depth = 2);
+									}
+								}
+							}
+
 							// set show/hide NPC names in rolls
 							if (d20plus.cfg.has("import", "showNpcNames") && !d20plus.cfg.get("import", "showNpcNames")) {
 								character.attribs.create({name: "npc_name_flag", current: 0});
@@ -1350,15 +1372,6 @@ function d20plusMonsters () {
 									istokenaction: true,
 									action: `%{${character.id}|shaped_actions}`,
 								});
-
-								// TODO lair action creation is unimplemented
-								/*
-								character.abilities.create({
-									name: "Lair Actions",
-									istokenaction: true,
-									action: `%{${character.id}|shaped_lairactions}`
-								});
-								*/
 							}
 
 							character.view.updateSheetValues();

--- a/js/5etools-monsters.js
+++ b/js/5etools-monsters.js
@@ -1353,10 +1353,10 @@ function d20plusMonsters () {
 								const legGroup = DataUtil.monster.getMetaGroup(data);
 								if (legGroup) {
 									if (legGroup.lairActions) {
-										renderFluff += renderer.render({entries: legGroup.lairActions, name: "Lair Actions"}, depth = 2);
+										renderFluff += renderer.render({entries: legGroup.lairActions, name: "Lair Actions"}, -1);
 									}
 									if (legGroup.regionalEffects) {
-										renderFluff += renderer.render({entries: legGroup.regionalEffects, name: "Regional Effects"}, depth = 2);
+										renderFluff += renderer.render({entries: legGroup.regionalEffects, name: "Regional Effects"}, -1);
 									}
 								}
 							}


### PR DESCRIPTION
Made it so that when you import monsters, their lair actions and regional effects, if any, appear in the Bio & Info section of their sheet.