### PR TITLE
Made vehicles importable

### DIFF
--- a/js/5etools-importer.js
+++ b/js/5etools-importer.js
@@ -801,7 +801,7 @@ function d20plusImporter () {
 				let remaining = importQueue.length;
 
 				let interval;
-				if (dataType === "monster" || dataType === "object") {
+				if (dataType === "monster" || dataType === "object" || dataType === "vehicle") {
 					interval = d20plus.cfg.get("import", "importIntervalCharacter") || d20plus.cfg.getDefault("import", "importIntervalCharacter");
 				} else {
 					interval = d20plus.cfg.get("import", "importIntervalHandout") || d20plus.cfg.getDefault("import", "importIntervalHandout");
@@ -1008,6 +1008,19 @@ function d20plusImporter () {
 				return folderName;
 			}
 			case "object": {
+				let folderName;
+				switch (groupBy) {
+					case "Source":
+						folderName = Parser.sourceJsonToFull(it.source);
+						break;
+					case "Alphabetical":
+					default:
+						folderName = it.name[0].uppercaseFirst();
+						break;
+				}
+				return folderName;
+			}
+			case "vehicle": {
 				let folderName;
 				switch (groupBy) {
 					case "Source":

--- a/js/5etools-importer.js
+++ b/js/5etools-importer.js
@@ -404,14 +404,18 @@ function d20plusImporter () {
 	d20plus.importer._addVehicleWeapon = function (character, weapon, renderer, prefix) {
 		const newRowId = d20plus.ut.generateRowId();
 		let desc = "";
+
+		// Locomotion mostly occurs in the movement section of UAOfShipsAndSea ships
 		if (weapon.locomotion) {
 			const locEntries = Renderer.vehicle.ship.getLocomotionEntries(weapon.locomotion[0]);
 			desc = d20plus.importer.getCleanText(renderer.render(locEntries));
 		}
-		if (weapon.speed) {
+		// Speed mostly occurs in the movement section of GoS ships
+		else if (weapon.speed) {
 			const speedEntries = Renderer.vehicle.ship.getSpeedEntries(weapon.speed[0]);
 			desc = d20plus.importer.getCleanText(renderer.render(speedEntries));
 		}
+		// This sets the description of non-movement weapons
 		else if (weapon.entries) {
 			desc = d20plus.importer.getCleanText(renderer.render({entries: weapon.entries}));
 		}
@@ -948,6 +952,16 @@ function d20plusImporter () {
 				doImport(importQueue);
 			}
 		});
+	};
+
+	// Import dialog showing names of monsters failed to import
+	d20plus.importer.addImportError = function (name) {
+		let $span = $("#import-errors");
+		if ($span.text() === "0") {
+			$span.text(name);
+		} else {
+			$span.text(`${$span.text()}, ${name}`);
+		}
 	};
 
 	d20plus.importer._getHandoutPath = function (dataType, it, groupBy) {

--- a/js/5etools-main.js
+++ b/js/5etools-main.js
@@ -82,11 +82,7 @@ const betteR205etoolsMain = function () {
 		"vehicle": [
 			"name",
 			"source",
-			"size",
 			"vehicleType",
-			"ac",
-			"hp",
-			"entries",
 		],
 		"class": [
 			"name",

--- a/js/5etools-main.js
+++ b/js/5etools-main.js
@@ -11,6 +11,7 @@ const betteR205etoolsMain = function () {
 	FEAT_DATA_URL = `${DATA_URL}feats.json`;
 	PSIONIC_DATA_URL = `${DATA_URL}psionics.json`;
 	OBJECT_DATA_URL = `${DATA_URL}objects.json`;
+	VEHICLE_DATA_URL = `${DATA_URL}vehicles.json`;
 	BACKGROUND_DATA_URL = `${DATA_URL}backgrounds.json`;
 	OPT_FEATURE_DATA_URL = `${DATA_URL}optionalfeatures.json`;
 	RACE_DATA_URL = `${DATA_URL}races.json`;
@@ -76,6 +77,15 @@ const betteR205etoolsMain = function () {
 			"ac",
 			"hp",
 			"immune",
+			"entries",
+		],
+		"vehicle": [
+			"name",
+			"source",
+			"size",
+			"vehicleType",
+			"ac",
+			"hp",
 			"entries",
 		],
 		"class": [
@@ -589,6 +599,7 @@ const betteR205etoolsMain = function () {
 			$wrpSettings.append(d20plus.settingsHtmlPtRaces);
 			$wrpSettings.append(d20plus.settingsHtmlPtFeats);
 			$wrpSettings.append(d20plus.settingsHtmlPtObjects);
+			$wrpSettings.append(d20plus.settingsHtmlPtVehicles);
 			$wrpSettings.append(d20plus.settingsHtmlPtClasses);
 			$wrpSettings.append(d20plus.settingsHtmlPtSubclasses);
 			$wrpSettings.append(d20plus.settingsHtmlPtBackgrounds);
@@ -603,6 +614,7 @@ const betteR205etoolsMain = function () {
 			$("#button-monsters-load-all").on(window.mousedowntype, d20plus.monsters.buttonAll);
 			$("#button-monsters-load-file").on(window.mousedowntype, d20plus.monsters.buttonFile);
 			$("#import-objects-load").on(window.mousedowntype, d20plus.objects.button);
+			$("#import-vehicles-load").on(window.mousedowntype, d20plus.vehicles.button);
 			$("#button-adventures-load").on(window.mousedowntype, d20plus.adventures.button);
 			$("#button-deities-load").on(window.mousedowntype, d20plus.deities.button);
 
@@ -619,6 +631,7 @@ const betteR205etoolsMain = function () {
 
 			populateDropdown("#button-monsters-select", "#import-monster-url", MONSTER_DATA_DIR, monsterDataUrls, "MM", ["monster"]);
 			populateBasicDropdown("#button-objects-select", "#import-objects-url", OBJECT_DATA_URL, ["object"]);
+			populateBasicDropdown("#button-vehicles-select", "#import-vehicles-url", VEHICLE_DATA_URL, ["vehicle"]);
 			populateBasicDropdown("#button-deities-select", "#import-deities-url", DEITY_DATA_URL, ["deity"]);
 
 			const populateAdventuresDropdown = () => {
@@ -1406,6 +1419,7 @@ Errors: <b id="import-errors">0</b>
 <option value="race">Races</option>
 <option value="spell">Spells</option>
 <option value="subclass">Subclasses</option>
+<option value="vehicle">Vehicles</option>
 </select>
 `;
 	d20plus.settingsHtmlSelectorPlayer = `
@@ -1542,6 +1556,16 @@ To import from third-party sources, either individually select one available in 
 <select id="button-objects-select"><!-- populate with JS--></select>
 <input type="text" id="import-objects-url">
 <a class="btn" href="#" id="import-objects-load">Import Objects</a>
+</div>
+`;
+
+d20plus.settingsHtmlPtVehicles = `
+<div class="importer-section" data-import-group="vehicle">
+<h4>Vehicle Importing</h4>
+<label for="import-vehicles-url">Vehicle Data URL:</label>
+<select id="button-vehicles-select"><!-- populate with JS--></select>
+<input type="text" id="import-vehicles-url">
+<a class="btn" href="#" id="import-vehicles-load">Import Vehicles</a>
 </div>
 `;
 

--- a/js/5etools-monsters.js
+++ b/js/5etools-monsters.js
@@ -248,16 +248,6 @@ function d20plusMonsters () {
 		return d20plus.formSrcUrl(MONSTER_DATA_DIR, fileName);
 	};
 
-	// Import dialog showing names of monsters failed to import
-	d20plus.monsters.addImportError = function (name) {
-		let $span = $("#import-errors");
-		if ($span.text() === "0") {
-			$span.text(name);
-		} else {
-			$span.text(`${$span.text()}, ${name}`);
-		}
-	};
-
 	// Get NPC size from chr
 	d20plus.monsters.getSizeString = function (chr) {
 		const result = Renderer.utils.getRenderedSize(chr);
@@ -1377,7 +1367,7 @@ function d20plusMonsters () {
 							}
 						} catch (e) {
 							d20plus.ut.log(`Error loading [${name}]`);
-							d20plus.monsters.addImportError(name);
+							d20plus.importer.addImportError(name);
 							// eslint-disable-next-line no-console
 							console.log(data, e);
 						}

--- a/js/5etools-objects.js
+++ b/js/5etools-objects.js
@@ -131,7 +131,7 @@ function d20plusObjects () {
 						}
 					} catch (e) {
 						d20plus.ut.log(`Error loading [${name}]`);
-						d20plus.monsters.addImportError(name);
+						d20plus.importer.addImportError(name);
 						// eslint-disable-next-line no-console
 						console.log(data, e);
 					}

--- a/js/5etools-vehicles.js
+++ b/js/5etools-vehicles.js
@@ -1,0 +1,155 @@
+function d20plusVehicles () {
+	d20plus.vehicles = {};
+
+	// Import Vehicle button was clicked
+	d20plus.vehicles.button = function () {
+		const url = $("#import-vehicles-url").val();
+
+		if (url && url.trim()) {
+			DataUtil.loadJSON(url).then((data) => {
+				d20plus.importer.addBrewMeta(data._meta);
+				d20plus.importer.showImportList(
+					"vehicle",
+					data.vehicle,
+					d20plus.vehicles.handoutBuilder,
+				);
+			});
+		}
+	};
+
+	d20plus.vehicles.handoutBuilder = function (data, overwrite, inJournals, folderName, saveIdsTo, options) {
+		// make dir
+		const folder = d20plus.journal.makeDirTree(`Vehicles`, folderName);
+		const path = ["Vehicles", ...folderName, data.name];
+
+		// handle duplicates/overwrites
+		if (!d20plus.importer._checkHandleDuplicate(path, overwrite)) return;
+
+		const name = data.name;
+		const source = data.source;
+		d20.Campaign.characters.create(
+			{
+				name: name,
+				tags: d20plus.importer.getTagString([
+					Renderer.utils.getRenderedSize(data.size),
+					Parser.vehicleTypeToFull(data.vehicleType),
+					Parser.sourceJsonToFull(data.source),
+				], "vehicle"),
+			},
+			{
+				success: function (character) {
+					if (saveIdsTo) saveIdsTo[UrlUtil.URL_TO_HASH_BUILDER[UrlUtil.PG_VEHICLES](data)] = {name: data.name, source: data.source, type: "character", roll20Id: character.id};
+
+					try {
+						const tokenUrl = `${IMG_URL}vehicles/tokens/${source}/${name}.png`;
+						const avatar = data.tokenUrl || Parser.nameToTokenName(tokenUrl);
+						character.size = data.size || "L";
+						character.name = name;
+						character.senses = data.senses ? data.senses instanceof Array ? data.senses.join(", ") : data.senses : null;
+						character.hp = data.hp;
+						$.ajax({
+							url: avatar,
+							type: "HEAD",
+							error: function () {
+								d20plus.importer.getSetAvatarImage(character, `${IMG_URL}blank.png`);
+							},
+							success: function () {
+								d20plus.importer.getSetAvatarImage(character, avatar);
+							},
+						});
+
+						const renderer = new Renderer();
+						renderer.setBaseUrl(BASE_SITE_URL);
+						
+						character.attribs.create({name: "npc", current: 1});
+						character.attribs.create({name: "npc_options-flag", current: 0});
+						character.attribs.create({name: "is_vehicle", current: 1});
+						// region disable charachtermancer
+						character.attribs.create({name: "mancer_confirm_flag", current: ""});
+						character.attribs.create({name: "l1mancer_status", current: "completed"});
+						// endregion
+						character.attribs.create({name: "wtype", current: d20plus.importer.getDesiredWhisperType()});
+						character.attribs.create({name: "rtype", current: d20plus.importer.getDesiredRollType()});
+						character.attribs.create({
+							name: "queryadvantage",
+							current: d20plus.importer.getDesiredAdvantageToggle(),
+						});
+						character.attribs.create({
+							name: "whispertoggle",
+							current: d20plus.importer.getDesiredWhisperToggle(),
+						});
+
+						const achpContainer = data.vehicleType === "INFWAR" ? data.hp : (data.hull || data);
+						const acType = achpContainer.acFrom ? achpContainer.acFrom[0] : Parser.vehicleTypeToFull(data.vehicleType);
+						let speed = "\u2014";
+						if (data.speed) speed = Parser.getSpeedString(data);
+						else if (data.pace) speed = `${data.pace * 10} ft.`;
+						const keel = data.dimensions ? data.dimensions[0].split(" ")[0] : "";
+						const beam = data.dimensions ? data.dimensions[1].split(" ")[0] : "";
+
+						character.attribs.create({name: "vehicle_ac", current: achpContainer.ac || ""});
+						character.attribs.create({name: "vehicle_actype", current: acType});
+						character.attribs.create({name: "vehicle_cargo", current: data.capCargo || ""});
+						character.attribs.create({name: "vehicle_hp", current: achpContainer.hp || ""});
+						character.attribs.create({name: "vehicle_crew", current: Renderer.vehicle.getShipCreatureCapacity(data)});
+						character.attribs.create({name: "vehicle_dt", current: achpContainer.dt || ""});
+						character.attribs.create({name: "vehicle_keel", current: keel});
+						character.attribs.create({name: "vehicle_beam", current: beam});
+						character.attribs.create({name: "vehicle_speed", current: speed});
+						character.attribs.create({name: "vehicle_cost", current: Parser.vehicleCostToFull(data)});
+						character.attribs.create({name: "ui_flags", current: ""});
+
+
+						if (data.weapon) {
+							data.weapon.forEach(w => {
+								const newRowId = d20plus.ut.generateRowId();
+								const desc = d20plus.importer.getCleanText(renderer.render({entries: w.entries}));
+								// Cost code stolen from Giddy
+								const cost = w.costs? w.costs.map(cost => {
+									return `${Parser.vehicleCostToFull(cost) || "\u2014"}${cost.note ? `  (${renderer.render(cost.note)})` : ""}`;
+								}).join(", ") : "\u2014";
+
+								character.attribs.create({name: `repeating_vehicleweapon_${newRowId}_name`, current: w.name});
+								character.attribs.create({name: `repeating_vehicleweapon_${newRowId}_quantity`, current: w.count || 1});
+								character.attribs.create({name: `repeating_vehicleweapon_${newRowId}_crew`, current: w.crew || ""});
+								character.attribs.create({name: `repeating_vehicleweapon_${newRowId}_actions`, current: "10"});
+								character.attribs.create({name: `repeating_vehicleweapon_${newRowId}_ac`, current: w.ac || ""});
+								character.attribs.create({name: `repeating_vehicleweapon_${newRowId}_hp`, current: w.hp || ""});
+								character.attribs.create({name: `repeating_vehicleweapon_${newRowId}_cost`, current: cost});
+								character.attribs.create({name: `repeating_vehicleweapon_${newRowId}_description`, current: desc});
+							})
+						}
+						d20plus.importer.addOrUpdateAttr(character, "ui_flags", "");
+						character.view.updateSheetValues();
+
+						if (data.entries) {
+							const bio = renderer.render({type: "entries", entries: data.entries});
+
+							setTimeout(() => {
+								const fluffAs = d20plus.cfg.get("import", "importFluffAs") || d20plus.cfg.getDefault("import", "importFluffAs");
+								let k = fluffAs === "Bio" ? "bio" : "gmnotes";
+								character.updateBlobs({
+									[k]: Markdown.parse(bio),
+								});
+								character.save({
+									[k]: (new Date()).getTime(),
+								});
+							}, 500);
+						}
+
+						d20plus.importer.addOrUpdateAttr(character, "ui_flags", "");
+						
+					} catch (e) {
+						d20plus.ut.log(`Error loading [${name}]`);
+						d20plus.monsters.addImportError(name);
+						// eslint-disable-next-line no-console
+						console.log(data, e);
+					}
+					d20.journal.addItemToFolderStructure(character.id, folder.id);
+				},
+			}
+		);
+	};
+}
+
+SCRIPT_EXTENSIONS.push(d20plusVehicles);

--- a/js/5etools-vehicles.js
+++ b/js/5etools-vehicles.js
@@ -81,6 +81,7 @@ function d20plusVehicles () {
 
 						const achpContainer = data.vehicleType === "INFWAR" ? data.hp : (data.hull || data);
 						const acType = achpContainer.acFrom ? achpContainer.acFrom[0] : Parser.vehicleTypeToFull(data.vehicleType);
+						const crew = data.capCreature ? Renderer.vehicle.getInfwarCreatureCapacity(data) : Renderer.vehicle.getShipCreatureCapacity(data);
 						let speed = "\u2014";
 						if (data.speed) speed = Parser.getSpeedString(data);
 						else if (data.pace) speed = `${data.pace * 10} ft.`;
@@ -91,38 +92,68 @@ function d20plusVehicles () {
 						character.attribs.create({name: "vehicle_actype", current: acType});
 						character.attribs.create({name: "vehicle_cargo", current: data.capCargo || ""});
 						character.attribs.create({name: "vehicle_hp", current: achpContainer.hp || ""});
-						character.attribs.create({name: "vehicle_crew", current: Renderer.vehicle.getShipCreatureCapacity(data)});
+						character.attribs.create({name: "vehicle_crew", current: crew});
 						character.attribs.create({name: "vehicle_dt", current: achpContainer.dt || ""});
 						character.attribs.create({name: "vehicle_keel", current: keel});
 						character.attribs.create({name: "vehicle_beam", current: beam});
 						character.attribs.create({name: "vehicle_speed", current: speed});
 						character.attribs.create({name: "vehicle_cost", current: Parser.vehicleCostToFull(data)});
-						character.attribs.create({name: "ui_flags", current: ""});
 
 
-						if (data.weapon) {
-							data.weapon.forEach(w => {
-								const newRowId = d20plus.ut.generateRowId();
-								const desc = d20plus.importer.getCleanText(renderer.render({entries: w.entries}));
-								// Cost code stolen from Giddy
-								const cost = w.costs? w.costs.map(cost => {
-									return `${Parser.vehicleCostToFull(cost) || "\u2014"}${cost.note ? `  (${renderer.render(cost.note)})` : ""}`;
-								}).join(", ") : "\u2014";
+						if (data.weapon) d20plus.importer.addVehicleWeapons(character, data.weapon, renderer);
+						if (data.control) d20plus.importer.addVehicleWeapons(character, data.control, renderer, "Control");
+						if (data.movement) d20plus.importer.addVehicleWeapons(character, data.movement, renderer, "Movement");
+						if (data.trait) d20plus.importer.addVehicleWeapons(character, data.trait, renderer, "Trait");
 
-								character.attribs.create({name: `repeating_vehicleweapon_${newRowId}_name`, current: w.name});
-								character.attribs.create({name: `repeating_vehicleweapon_${newRowId}_quantity`, current: w.count || 1});
-								character.attribs.create({name: `repeating_vehicleweapon_${newRowId}_crew`, current: w.crew || ""});
-								character.attribs.create({name: `repeating_vehicleweapon_${newRowId}_actions`, current: "10"});
-								character.attribs.create({name: `repeating_vehicleweapon_${newRowId}_ac`, current: w.ac || ""});
-								character.attribs.create({name: `repeating_vehicleweapon_${newRowId}_hp`, current: w.hp || ""});
-								character.attribs.create({name: `repeating_vehicleweapon_${newRowId}_cost`, current: cost});
-								character.attribs.create({name: `repeating_vehicleweapon_${newRowId}_description`, current: desc});
-							})
+						let numActions = 0;
+
+						if (data.other) {
+							const name = d20plus.importer.getCleanText(renderer.render(data.other[0].name));
+							const text = d20plus.importer.getCleanText(renderer.render({entries: data.other[0].entries}, 1)).replace(/^\s*Hit:\s*/, "");
+							d20plus.importer.addVehicleAction(character, name, text, numActions++);
 						}
-						d20plus.importer.addOrUpdateAttr(character, "ui_flags", "");
+						if (data.action) {
+							const text = d20plus.importer.getCleanText(renderer.render(data.action[0], 1)).replace(/^\s*Hit:\s*/, "");
+							d20plus.importer.addVehicleAction(character, "Actions", text, numActions++);
+
+							data.action[1].items.forEach((a, i) => {
+								const name = d20plus.importer.getCleanText(renderer.render(a.name));
+
+								let actionEntries = [];
+								if (data.weapon && i < data.weapon.length) actionEntries = data.weapon[i].entries
+								actionEntries.push(a.entry);
+
+								const text = d20plus.importer.getCleanText(renderer.render({entries: actionEntries}, 1)).replace(/^\s*Hit:\s*/, "");
+								d20plus.importer.addVehicleAction(character, name, text, numActions++);
+							});
+						}
+						else if (data.actionStation) {
+							data.actionStation.forEach(a => {
+								const name = d20plus.importer.getCleanText(renderer.render(a.name));
+								const text = d20plus.importer.getCleanText(renderer.render({entries: a.entries}, 1)).replace(/^\s*Hit:\s*/, "");
+								d20plus.importer.addVehicleAction(character, name, text, numActions++);
+							});
+						}
+						else if (data.weapon) {
+							data.weapon.forEach(w => {
+								if (w.action) {
+									w.action.forEach(a => {
+										const name = d20plus.importer.getCleanText(renderer.render(a.name));
+										const text = d20plus.importer.getCleanText(renderer.render({entries: a.entries.concat(w.entries)}, 1)).replace(/^\s*Hit:\s*/, "");
+										d20plus.importer.addVehicleAction(character, name, text, numActions++);
+									});
+								}
+								else if (w.entries) {
+									const name = d20plus.importer.getCleanText(renderer.render(w.name));
+									const text = d20plus.importer.getCleanText(renderer.render({entries: w.entries}, 1)).replace(/^\s*Hit:\s*/, "");
+									d20plus.importer.addVehicleAction(character, name, text, numActions++);
+								}
+							});
+						}
+
 						character.view.updateSheetValues();
 
-						if (data.entries) {
+						/*if (data.entries) {
 							const bio = renderer.render({type: "entries", entries: data.entries});
 
 							setTimeout(() => {
@@ -135,10 +166,9 @@ function d20plusVehicles () {
 									[k]: (new Date()).getTime(),
 								});
 							}, 500);
-						}
+						}*/
 
-						d20plus.importer.addOrUpdateAttr(character, "ui_flags", "");
-						
+
 					} catch (e) {
 						d20plus.ut.log(`Error loading [${name}]`);
 						d20plus.monsters.addImportError(name);

--- a/js/5etools-vehicles.js
+++ b/js/5etools-vehicles.js
@@ -3,7 +3,7 @@ function d20plusVehicles () {
 	
 	d20plus.vehicles.fluff = null;
 
-	d20plus.vehicles.loadFluff = function () {
+	d20plus.vehicles._loadFluff = function () {
 		// To prevent loading the fluff multiple times
 		if (d20plus.vehicles.fluff) return;
 
@@ -13,7 +13,62 @@ function d20plusVehicles () {
 		}).catch(e => {
 			// eslint-disable-next-line no-console
 			console.error(e);
-		})
+		});
+	}
+
+	// Given the action name and entries, add an action
+	d20plus.vehicles._addAction = function (character, renderer, actionName, entries, numActions) {
+		const name = d20plus.importer.getCleanText(renderer.render(actionName));
+		const text = d20plus.importer.getCleanText(renderer.render({entries: entries}, 1)).replace(/^\s*Hit:\s*/, "");
+		d20plus.importer.addVehicleAction(character, name, text, numActions);
+	}
+
+	// Sets the image, mostly stolen from Giddy
+	d20plus.vehicles._setFluffImage = function (character, data, fluff) {
+		const tokenUrl = `${IMG_URL}vehicles/tokens/${data.source}/${data.name}.png`;
+		const avatar = data.tokenUrl || Parser.nameToTokenName(tokenUrl);
+		console.log(avatar);
+		const firstFluffImage = d20plus.cfg.getOrDefault("import", "importCharAvatar") === "Portrait (where available)" && fluff && fluff.images ? 
+			(() => {
+			const firstImage = fluff.images[0] || {};
+			return (firstImage.href || {}).type === "internal" ? `${BASE_SITE_URL}/img/${firstImage.href.path}` : (firstImage.href || {}).url;
+		})() : null;
+		$.ajax({
+			url: avatar,
+			type: "HEAD",
+			error: function () {
+				d20plus.importer.getSetAvatarImage(character, `${IMG_URL}blank.png`, firstFluffImage);
+			},
+			success: function () {
+				d20plus.importer.getSetAvatarImage(character, avatar, firstFluffImage);
+			},
+		});
+	}
+
+	// Sets fluff text, mostly stolen from Giddy
+	d20plus.vehicles._setFluff = function (character, data, fluff, renderer) {
+		let renderFluff;
+		if (data.entries) {
+			renderFluff = renderer.render({entries: data.entries}, 1);
+		}
+		if (fluff && data.hasFluff) {
+			const depth = fluff.type === "section" ? -1 : 2;
+			if (fluff.type !== "section") renderer.setFirstSection(false);
+			renderFluff = renderer.render({type: fluff.type, entries: fluff.entries || []}, depth);
+		}
+
+		if (renderFluff) {
+			setTimeout(() => {
+				const fluffAs = d20plus.cfg.get("import", "importFluffAs") || d20plus.cfg.getDefault("import", "importFluffAs");
+				let k = fluffAs === "Bio" ? "bio" : "gmnotes";
+				character.updateBlobs({
+					[k]: Markdown.parse(renderFluff),
+				});
+				character.save({
+					[k]: (new Date()).getTime(),
+				});
+			}, 500);
+		}
 	}
 
 	// Import Vehicle button was clicked
@@ -34,7 +89,7 @@ function d20plusVehicles () {
 
 	d20plus.vehicles.handoutBuilder = function (data, overwrite, inJournals, folderName, saveIdsTo, options) {
 		// First make sure the fluff is there
-		d20plus.vehicles.loadFluff();
+		d20plus.vehicles._loadFluff();
 		
 		// make dir
 		const folder = d20plus.journal.makeDirTree(`Vehicles`, folderName);
@@ -59,29 +114,10 @@ function d20plusVehicles () {
 					if (saveIdsTo) saveIdsTo[UrlUtil.URL_TO_HASH_BUILDER[UrlUtil.PG_VEHICLES](data)] = {name: data.name, source: data.source, type: "character", roll20Id: character.id};
 
 					try {
-						const tokenUrl = `${IMG_URL}vehicles/tokens/${source}/${name}.png`;
-						const avatar = data.tokenUrl || Parser.nameToTokenName(tokenUrl);
 						character.size = data.size || "L";
 						character.name = name;
 						character.senses = data.senses ? data.senses instanceof Array ? data.senses.join(", ") : data.senses : null;
 						character.hp = data.hp;
-
-						const fluff = d20plus.vehicles.fluff?.find(it => it.name === data.name && it.source === data.source);
-						const firstFluffImage = d20plus.cfg.getOrDefault("import", "importCharAvatar") === "Portrait (where available)" && fluff && fluff.images ? 
-						(() => {
-							const firstImage = fluff.images[0] || {};
-							return (firstImage.href || {}).type === "internal" ? `${BASE_SITE_URL}/img/${firstImage.href.path}` : (firstImage.href || {}).url;
-						})() : null;
-						$.ajax({
-							url: avatar,
-							type: "HEAD",
-							error: function () {
-								d20plus.importer.getSetAvatarImage(character, `${IMG_URL}blank.png`, firstFluffImage);
-							},
-							success: function () {
-								d20plus.importer.getSetAvatarImage(character, avatar, firstFluffImage);
-							},
-						});
 
 						const renderer = new Renderer();
 						renderer.setBaseUrl(BASE_SITE_URL);
@@ -104,6 +140,7 @@ function d20plusVehicles () {
 							current: d20plus.importer.getDesiredWhisperToggle(),
 						});
 
+						// Setting the basic vehicle variables
 						const achpContainer = data.vehicleType === "INFWAR" ? data.hp : (data.hull || data);
 						const acType = achpContainer.acFrom ? achpContainer.acFrom[0] : Parser.vehicleTypeToFull(data.vehicleType);
 						const crew = data.capCreature ? Renderer.vehicle.getInfwarCreatureCapacity(data) : Renderer.vehicle.getShipCreatureCapacity(data);
@@ -125,6 +162,7 @@ function d20plusVehicles () {
 						character.attribs.create({name: "vehicle_cost", current: Parser.vehicleCostToFull(data)});
 
 
+						// This adds weapons, or anything that might end up in the weapon catagory
 						if (data.weapon) d20plus.importer.addVehicleWeapons(character, data.weapon, renderer);
 						if (data.control) d20plus.importer.addVehicleWeapons(character, data.control, renderer, "Control");
 						if (data.movement) d20plus.importer.addVehicleWeapons(character, data.movement, renderer, "Movement");
@@ -132,85 +170,48 @@ function d20plusVehicles () {
 
 						let numActions = 0;
 
+						// Some ships (mostly UA) have an other catagory that contains an action explaining how that ship's actions work
 						if (data.other) {
-							const name = d20plus.importer.getCleanText(renderer.render(data.other[0].name));
-							const text = d20plus.importer.getCleanText(renderer.render({entries: data.other[0].entries}, 1)).replace(/^\s*Hit:\s*/, "");
-							d20plus.importer.addVehicleAction(character, name, text, numActions++);
+							d20plus.vehicles._addAction(character, renderer, data.other[0].name, data.other[0].entries, numActions++);
 						}
+						// Mostly GoS ships
 						if (data.action) {
 							const text = d20plus.importer.getCleanText(renderer.render(data.action[0], 1)).replace(/^\s*Hit:\s*/, "");
 							d20plus.importer.addVehicleAction(character, "Actions", text, numActions++);
 
 							data.action[1].items.forEach((a, i) => {
-								const name = d20plus.importer.getCleanText(renderer.render(a.name));
-
 								let actionEntries = [];
-								if (data.weapon && i < data.weapon.length) actionEntries = data.weapon[i].entries
+								if (data.weapon && i < data.weapon.length) actionEntries = data.weapon[i].entries;
 								actionEntries.push(a.entry);
-
-								const text = d20plus.importer.getCleanText(renderer.render({entries: actionEntries}, 1)).replace(/^\s*Hit:\s*/, "");
-								d20plus.importer.addVehicleAction(character, name, text, numActions++);
+								d20plus.vehicles._addAction(character, renderer, a.name, actionEntries, numActions++);
 							});
 						}
+						// Mostly DiA war machines
 						else if (data.actionStation) {
 							data.actionStation.forEach(a => {
-								const name = d20plus.importer.getCleanText(renderer.render(a.name));
-								const text = d20plus.importer.getCleanText(renderer.render({entries: a.entries}, 1)).replace(/^\s*Hit:\s*/, "");
-								d20plus.importer.addVehicleAction(character, name, text, numActions++);
+								d20plus.vehicles._addAction(character, renderer, a.name, a.entries, numActions++);
 							});
 						}
+						// Sort of a catch all but works especially well with spelljammer
 						else if (data.weapon) {
 							data.weapon.forEach(w => {
 								if (w.action) {
 									w.action.forEach(a => {
-										const name = d20plus.importer.getCleanText(renderer.render(a.name));
-										const text = d20plus.importer.getCleanText(renderer.render({entries: a.entries.concat(w.entries)}, 1)).replace(/^\s*Hit:\s*/, "");
-										d20plus.importer.addVehicleAction(character, name, text, numActions++);
+										d20plus.vehicles._addAction(character, renderer, a.name, a.entries.concat(w.entries), numActions++);
 									});
 								}
 								else if (w.entries) {
-									const name = d20plus.importer.getCleanText(renderer.render(w.name));
-									const text = d20plus.importer.getCleanText(renderer.render({entries: w.entries}, 1)).replace(/^\s*Hit:\s*/, "");
-									d20plus.importer.addVehicleAction(character, name, text, numActions++);
+									d20plus.vehicles._addAction(character, renderer, w.name, w.entries, numActions++);
 								}
 							});
 						}
 
 						character.view.updateSheetValues();
 
-						if (data.entries) {
-							const renderFluff = renderer.render({entries: data.entries}, 1);
-							if (renderFluff) {
-								setTimeout(() => {
-									const fluffAs = d20plus.cfg.get("import", "importFluffAs") || d20plus.cfg.getDefault("import", "importFluffAs");
-									let k = fluffAs === "Bio" ? "bio" : "gmnotes";
-									character.updateBlobs({
-										[k]: Markdown.parse(renderFluff),
-									});
-									character.save({
-										[k]: (new Date()).getTime(),
-									});
-								}, 500);
-							}
-						}
-
-						if (fluff && data.hasFluff) {
-							const depth = fluff.type === "section" ? -1 : 2;
-							if (fluff.type !== "section") renderer.setFirstSection(false);
-							const renderFluff = renderer.render({type: fluff.type, entries: fluff.entries || []}, depth);
-							if (renderFluff) {
-								setTimeout(() => {
-									const fluffAs = d20plus.cfg.get("import", "importFluffAs") || d20plus.cfg.getDefault("import", "importFluffAs");
-									let k = fluffAs === "Bio" ? "bio" : "gmnotes";
-									character.updateBlobs({
-										[k]: Markdown.parse(renderFluff),
-									});
-									character.save({
-										[k]: (new Date()).getTime(),
-									});
-								}, 500);
-							}
-						}
+						// Deal with fluff and images here
+						const fluff = d20plus.vehicles.fluff?.find(it => it.name === data.name && it.source === data.source);
+						d20plus.vehicles._setFluffImage(character, data, fluff);
+						d20plus.vehicles._setFluff(character, data, fluff, renderer);
 
 
 					} catch (e) {

--- a/js/5etools-vehicles.js
+++ b/js/5etools-vehicles.js
@@ -3,7 +3,7 @@ function d20plusVehicles () {
 	
 	d20plus.vehicles.fluff = null;
 
-	d20plus.vehicles._loadFluff = function () {
+	d20plus.vehicles._loadFluff = async function () {
 		// To prevent loading the fluff multiple times
 		if (d20plus.vehicles.fluff) return;
 
@@ -87,9 +87,9 @@ function d20plusVehicles () {
 		}
 	};
 
-	d20plus.vehicles.handoutBuilder = function (data, overwrite, inJournals, folderName, saveIdsTo, options) {
+	d20plus.vehicles.handoutBuilder = async function (data, overwrite, inJournals, folderName, saveIdsTo, options) {
 		// First make sure the fluff is there
-		d20plus.vehicles._loadFluff();
+		await d20plus.vehicles._loadFluff();
 		
 		// make dir
 		const folder = d20plus.journal.makeDirTree(`Vehicles`, folderName);
@@ -175,7 +175,7 @@ function d20plusVehicles () {
 							d20plus.vehicles._addAction(character, renderer, data.other[0].name, data.other[0].entries, numActions++);
 						}
 						// Mostly GoS ships
-						if (data.action) {
+						if (data.action && typeof data.action[0] === "string") {
 							const text = d20plus.importer.getCleanText(renderer.render(data.action[0], 1)).replace(/^\s*Hit:\s*/, "");
 							d20plus.importer.addVehicleAction(character, "Actions", text, numActions++);
 
@@ -186,7 +186,13 @@ function d20plusVehicles () {
 								d20plus.vehicles._addAction(character, renderer, a.name, actionEntries, numActions++);
 							});
 						}
-						// Mostly DiA war machines
+						// Litterally just the Stahlmaster
+						else if (data.action) {
+							data.action.forEach(a => {
+								d20plus.vehicles._addAction(character, renderer, a.name, a.entries, numActions++);
+							});
+						}
+						// Mostly BGDIA infernal war machines
 						else if (data.actionStation) {
 							data.actionStation.forEach(a => {
 								d20plus.vehicles._addAction(character, renderer, a.name, a.entries, numActions++);
@@ -216,7 +222,7 @@ function d20plusVehicles () {
 
 					} catch (e) {
 						d20plus.ut.log(`Error loading [${name}]`);
-						d20plus.monsters.addImportError(name);
+						d20plus.importer.addImportError(name);
 						// eslint-disable-next-line no-console
 						console.log(data, e);
 					}

--- a/node/build-scripts.js
+++ b/node/build-scripts.js
@@ -224,6 +224,7 @@ const SCRIPTS = {
 			"5etools-optional-features",
 			"5etools-adventures",
 			"5etools-deities",
+			"5etools-vehicles",
 
 			"base"
 		]


### PR DESCRIPTION
Added an option to import vehicles using the new roll20 character sheet just like you would objects or monsters. As far as I can tell, it accommodates all the JSON weirdness, and works especially well with spelljammer. Might need some updating as the roll20 sheet evolves and gets more flexible, but this should do fine for now.

Note on testing: this code requires some of the newer libs, but if you update them you need to roll some of them back because some lib updates break things. I'll submit an PR with working libs soon.