### PR TITLE
Fix: art repo & dark mode styles

### DIFF
--- a/js/base-css.js
+++ b/js/base-css.js
@@ -447,6 +447,18 @@ function baseCss () {
 			s: "#editinglayer.background .currentselection:after",
 			r: "content: \"a\";",
 		},
+		{
+			s: "#editinglayer.gmlayer .currentselection:after",
+			r: "content: \"E\";",
+		},
+		{
+			s: "#editinglayer.gmlayer > span.currentselection",
+			r: "display:unset;",
+		},
+		{
+			s: "#editinglayer.gmlayer #editing_layer_icon",
+			r: "display:none;",
+		},
 		// adjust the "Talking to Yourself" box
 		{
 			s: "#textchat-notifier",

--- a/js/base-css.js
+++ b/js/base-css.js
@@ -831,6 +831,19 @@ function baseCss () {
 			s: ".artr__big_img",
 			r: "display: block; max-width: 100%; max-height: 100%;",
 		},
+		// fix row styles
+		{
+			s: "#d20plus-artfolder .url",
+			r: "width: calc(65% - 75px) !important;white-space: nowrap;overflow: hidden;",
+		},
+		{
+			s: "#d20plus-artfolder .library-item",
+			r: "line-height: 16px;",
+		},
+		{
+			s: "#d20plus-artfolder .library-item:hover",
+			r: "background-color: rgba(100,100,100,0.5);",
+		},
 	]);
 
 	// Animator CSS -- `anm__` prefix

--- a/js/base-css.js
+++ b/js/base-css.js
@@ -400,6 +400,36 @@ function baseCss () {
 			s: "#floatinglayerbar",
 			r: "left: 20px;",
 		},
+		// Config & dark mode fixes
+		{
+			s: ".config-name",
+			r: "padding: 6px 0px; line-height: 21px;",
+		},
+		{
+			s: "#d20plus-configeditor .nav li:not(.active) > a",
+			r: "cursor: pointer;",
+		},
+		{
+			s: "#d20plus-configeditor table.config-table tbody tr:nth-child(2n+1)",
+			r: "background-color: rgba(120, 120, 120, 0.2);",
+		},
+		{
+			s: ".tokeneditor__bar-inputs input[type=\"text\"][disabled], .token_bar_input[disabled]",
+			r: "background-color: rgba(180, 180, 180, 0.3);",
+		},
+		{
+			s: ".tool-row:nth-child(2n+1)",
+			r: "background-color: rgba(120, 120, 120, 0.2);",
+		},
+		{
+			s: "#floatinglayerbar li",
+			r: "background-color: var(--dark-surface2);border-color: var(--dark-surface1);",
+		},
+		// Fix page options scrollbar color in darkmode on Chrome
+		{
+			s: ".ui-dialog-content::-webkit-scrollbar-thumb",
+			r: "background-color: rgba(100, 100, 100, 0.5);",
+		},
 		// extra layer buttons
 		{
 			s: "#editinglayer.weather div.submenu li.chooseweather, #editinglayer.foreground div.submenu li.chooseforeground, #editinglayer.background div.submenu li.choosebackground",

--- a/js/templates/template-base-misc.js
+++ b/js/templates/template-base-misc.js
@@ -25,7 +25,7 @@ function initHTMLbaseMisc () {
 	`;
 
 	d20plus.html.addArtHTML = `
-	<div id="d20plus-artfolder" title="BetteR20 - External Art" style="position: relative">
+	<div id="d20plus-artfolder" title="BetteR20 - External Art" style="position: relative; background: inherit;">
 		<p>Add external images by URL. Any direct link to an image should work.</p>
 		<p>
 			<input placeholder="Name*" id="art-list-add-name">
@@ -35,16 +35,18 @@ function initHTMLbaseMisc () {
 			<a class="btn btn-danger" href="#" id="art-list-delete-all-btn" style="margin-left: 12px;">Delete All</a>
 			<p />
 			<hr>
-		<div id="art-list-container">
-			<input class="search" autocomplete="off" placeholder="Search list..." style="width: 100%;">
-			<br>
-			<p>
-				<span style="display: inline-block; width: 40%; font-weight: bold;">Name</span>
+		<div id="art-list-container" style="background: inherit;">
+			<p style="position: sticky; top: -10px; background: inherit; z-index: 100;">
+				<span style="display: inline-block; width: calc( 35% + 35px ); font-weight: bold;">
+					Name
+					<input class="search" autocomplete="off" placeholder="Search list..." style="width: 60%; margin: 10px;">
+				</span>
 				<span style="display: inline-block; font-weight: bold;">URL</span>
 			</p>
-			<ul class="list artlist" style="max-height: 600px; overflow-y: scroll; display: block; margin: 0; transform: translateZ(0);"></ul>
+			<ul class="list artlist" style="display: block; margin: 0; transform: translateZ(0);"></ul>
 		</div>
 	</div>
+	<br>
 	`;
 
 	d20plus.html.addArtMassAdderHTML = `


### PR DESCRIPTION
External art lib:

- removed second scrollbar
- fixed row backgrounds & buttons
- made list header sticky
- moved search field to Name header

Fixes for Roll20 dark mode
(e.g. some parts were white instead of dark):

- fix betteR20 config rows
- fix layer toolbar
- fix gmlayer icon
- fix page options scrollbar barely visible in Chrome
- fix new inactive bar values in token editor