### PR TITLE
fixed exporting not including monster data

### DIFF
--- a/js/base-tool-module.js
+++ b/js/base-tool-module.js
@@ -690,6 +690,7 @@ function baseToolModule () {
 						// eslint-disable-next-line no-console
 						console.log("Exporting characters...");
 						characters = d20.Campaign.characters.models.map(character => {
+							character.attribs.fetch(character.attribs);
 							const out = {
 								attributes: character.attributes,
 								attribs: character.attribs,


### PR DESCRIPTION
Fixed exporting not including character data by loading data on export. May not be comprehensive but certainly passes a quick test and is better than before. Redweller should be credited as well, as he found the actual function. I just threw the code together.