### PR TITLE
Improved adventure import dialog

### DIFF
--- a/js/5etools-adventures.js
+++ b/js/5etools-adventures.js
@@ -8,222 +8,220 @@ function d20plusAdventure () {
 	};
 
 	// Fetch adventure data from file
-	d20plus.adventures.load = function (url) {
+	d20plus.adventures.load = async function (url) {
 		$("a.ui-tabs-anchor[href='#journal']").trigger("click");
-		DataUtil.loadJSON(url)
-			.then(async data => {
-				function isPart (e) {
-					return typeof e === "string" || (typeof e === "object" && (e.type !== "entries"));
+		const data = await DataUtil.loadJSON(url);
+
+		function isPart (e) {
+			return typeof e === "string" || (typeof e === "object" && (e.type !== "entries"));
+		}
+
+		// open progress window
+		$("#d20plus-import").dialog("open");
+		$("#import-remaining").text("Initialising...");
+
+		// FIXME(homebrew) this always selects the first item in a list of homebrew adventures
+		// FIXME(5etools) this selects the source based on the select dropdown, which can be wrong
+		// get metadata
+		const adMeta = data.adventure
+			? data.adventure[0]
+			: adventureMetadata.adventure.find(a => a.id.toLowerCase() === $("#import-adventures-url").data("id").toLowerCase());
+
+		const addQueue = [];
+		const sections = JSON.parse(JSON.stringify(data.adventureData ? data.adventureData[0].data : data.data));
+		const adDir = `${Parser.sourceJsonToFull(adMeta.id)}`;
+		sections.forEach((s, i) => {
+			if (i >= adMeta.contents.length) return;
+
+			const chapterDir = [adDir, adMeta.contents[i].name];
+
+			const introEntries = [];
+			if (s.entries && s.entries.length && isPart(s.entries[0])) {
+				while (isPart(s.entries[0])) {
+					introEntries.push(s.entries[0]);
+					s.entries.shift();
 				}
+			}
+			addQueue.push({
+				dir: chapterDir,
+				type: "entries",
+				name: s.name,
+				entries: introEntries,
+			});
 
-				// open progress window
-				$("#d20plus-import").dialog("open");
-				$("#import-remaining").text("Initialising...");
-
-				// FIXME(homebrew) this always selects the first item in a list of homebrew adventures
-				// FIXME(5etools) this selects the source based on the select dropdown, which can be wrong
-				// get metadata
-				const adMeta = data.adventure
-					? data.adventure[0]
-					: adventureMetadata.adventure.find(a => a.id.toLowerCase() === $("#import-adventures-url").data("id").toLowerCase());
-
-				const addQueue = [];
-				const sections = JSON.parse(JSON.stringify(data.adventureData ? data.adventureData[0].data : data.data));
-				const adDir = `${Parser.sourceJsonToFull(adMeta.id)}`;
-				sections.forEach((s, i) => {
-					if (i >= adMeta.contents.length) return;
-
-					const chapterDir = [adDir, adMeta.contents[i].name];
-
-					const introEntries = [];
-					if (s.entries && s.entries.length && isPart(s.entries[0])) {
-						while (isPart(s.entries[0])) {
-							introEntries.push(s.entries[0]);
-							s.entries.shift();
-						}
-					}
-					addQueue.push({
-						dir: chapterDir,
-						type: "entries",
-						name: s.name,
-						entries: introEntries,
-					});
-
-					// compact entries into layers
-					front = null;
-					let tempStack = [];
-					let textIndex = 1;
-					while ((front = s.entries.shift())) {
-						if (isPart(front)) {
-							tempStack.push(front);
-						} else {
-							if (tempStack.length) {
-								addQueue.push({
-									dir: chapterDir,
-									type: "entries",
-									name: `Text ${textIndex++}`,
-									entries: tempStack,
-								});
-								tempStack = [];
-							}
-							front.dir = chapterDir;
-							addQueue.push(front);
-						}
-					}
-				});
-
-				const renderer = new Renderer();
-				renderer.setBaseUrl(BASE_SITE_URL);
-
-				const $stsName = $("#import-name");
-				const $stsRemain = $("#import-remaining");
-				const interval = d20plus.cfg.get("import", "importIntervalHandout") || d20plus.cfg.getDefault("import", "importIntervalHandout");
-
-				/// /////////////////////////////////////////////////////////////////////////////////////////////////////
-				Renderer.get().setBaseUrl(BASE_SITE_URL);
-				// pre-import tags
-				const tags = {};
-				renderer.doExportTags(tags);
-				addQueue.forEach(entry => {
-					renderer.recursiveRender(entry, []);
-				});
-
-				// storage for returned handout/character IDs
-				const RETURNED_IDS = {};
-
-				// Check to see what should be imported
-				const toImport = await d20plus.ui.chooseCheckboxList(["Creatures", "Items", "Handouts"], "What to import for this adventure?");
-				console.log(toImport);
-
-				// monsters
-				const preMonsters = Object.keys(tags)
-					.filter(k => tags[k].page === "bestiary.html")
-					.map(k => tags[k]);
-				if (toImport.includes("Creatures")) doPreImport(preMonsters, showMonsterImport);
-				else doItemImport();
-
-				function showMonsterImport (toImport) {
-					d20plus.ut.log(`Displaying monster import list for [${adMeta.name}]`);
-					d20plus.importer.showImportList(
-						"monster",
-						toImport.filter(it => it),
-						d20plus.monsters.handoutBuilder,
-						{
-							groupOptions: d20plus.monsters._groupOptions,
-							saveIdsTo: RETURNED_IDS,
-							callback: doItemImport,
-							listItemBuilder: d20plus.monsters._listItemBuilder,
-							listIndex: d20plus.monsters._listCols,
-							listIndexConverter: d20plus.monsters._listIndexConverter,
-						},
-					);
-				}
-
-				// items
-				function doItemImport () {
-					const preItems = Object.keys(tags)
-						.filter(k => tags[k].page === "items.html")
-						.map(k => tags[k]);
-					if (toImport.includes("Items")) doPreImport(preItems, showItemImport);
-					else doMainImport();
-				}
-
-				function showItemImport (toImport) {
-					d20plus.ut.log(`Displaying item import list for [${adMeta.name}]`);
-					d20plus.importer.showImportList(
-						"item",
-						toImport.filter(it => it),
-						d20plus.items.handoutBuilder,
-						{
-							groupOptions: d20plus.items._groupOptions,
-							saveIdsTo: RETURNED_IDS,
-							callback: doMainImport,
-							listItemBuilder: d20plus.items._listItemBuilder,
-							listIndex: d20plus.items._listCols,
-							listIndexConverter: d20plus.items._listIndexConverter,
-						},
-					);
-				}
-
-				function doPreImport (asTags, callback) {
-					const tmp = [];
-					let cachedCount = asTags.length;
-					// FIXME crappy inefficient conversion to promise-based version; requires cleanup
-					asTags.forEach(async it => {
-						try {
-							await Renderer.hover.pCacheAndGet(it.page, it.source, it.hash);
-							tmp.push(Renderer.hover.getFromCache(it.page, it.source, it.hash));
-							cachedCount--;
-							if (cachedCount <= 0) callback(tmp);
-						} catch (x) {
-							// eslint-disable-next-line no-console
-							console.log(x);
-							cachedCount--;
-							if (cachedCount <= 0) callback(tmp);
-						}
-					});
-				}
-				/// /////////////////////////////////////////////////////////////////////////////////////////////////////
-				function doMainImport () {
-					// Check to make sure the user wants to import everything
-					if (!toImport.includes("Handouts")) {
-						$("#d20plus-import").dialog("close");
-						return;
-					}
-
-					// pass in any created handouts/characters to use for links in the renderer
-					renderer.setRoll20Ids(RETURNED_IDS);
-
-					let cancelWorker = false;
-					const $btnCancel = $(`#importcancel`);
-					$btnCancel.off("click");
-					$btnCancel.on("click", () => {
-						cancelWorker = true;
-					});
-
-					let remaining = addQueue.length;
-
-					d20plus.ut.log(`Running import of [${adMeta.name}] with ${interval} ms delay between each handout create`);
-					let lastId = null;
-					let lastName = null;
-
-					const worker = setInterval(() => {
-						if (!addQueue.length || cancelWorker) {
-							clearInterval(worker);
-							$stsName.text("DONE!");
-							$stsRemain.text("0");
-							d20plus.ut.log(`Finished import of [${adMeta.name}]`);
-							renderer.resetRoll20Ids();
-							return;
-						}
-
-						// pull items out the queue in LIFO order, for journal ordering (last created will be at the top)
-						const entry = addQueue.pop();
-						entry.name = entry.name || "(Unknown)";
-						entry.name = d20plus.importer.getCleanText(renderer.render(entry.name));
-						$stsName.text(entry.name);
-						$stsRemain.text(remaining--);
-						const folder = d20plus.journal.makeDirTree(entry.dir);
-
-						d20.Campaign.handouts.create({
-							name: entry.name,
-						}, {
-							success: function (handout) {
-								const renderStack = [];
-								renderer.recursiveRender(entry, renderStack);
-								if (lastId && lastName) renderStack.push(`<br><p>Next handout: <a href="http://journal.roll20.net/handout/${lastId}">${lastName}</a></p>`);
-								const rendered = renderStack.join("");
-
-								lastId = handout.id;
-								lastName = entry.name;
-								handout.updateBlobs({notes: rendered});
-								handout.save({notes: (new Date()).getTime(), inplayerjournals: ""});
-								d20.journal.addItemToFolderStructure(handout.id, folder.id);
-							},
+			// compact entries into layers
+			front = null;
+			let tempStack = [];
+			let textIndex = 1;
+			while ((front = s.entries.shift())) {
+				if (isPart(front)) {
+					tempStack.push(front);
+				} else {
+					if (tempStack.length) {
+						addQueue.push({
+							dir: chapterDir,
+							type: "entries",
+							name: `Text ${textIndex++}`,
+							entries: tempStack,
 						});
-					}, interval);
+						tempStack = [];
+					}
+					front.dir = chapterDir;
+					addQueue.push(front);
+				}
+			}
+		});
+
+		const renderer = new Renderer();
+		renderer.setBaseUrl(BASE_SITE_URL);
+
+		const $stsName = $("#import-name");
+		const $stsRemain = $("#import-remaining");
+		const interval = d20plus.cfg.get("import", "importIntervalHandout") || d20plus.cfg.getDefault("import", "importIntervalHandout");
+
+		/// /////////////////////////////////////////////////////////////////////////////////////////////////////
+		Renderer.get().setBaseUrl(BASE_SITE_URL);
+		// pre-import tags
+		const tags = {};
+		renderer.doExportTags(tags);
+		addQueue.forEach(entry => {
+			renderer.recursiveRender(entry, []);
+		});
+
+		// storage for returned handout/character IDs
+		const RETURNED_IDS = {};
+
+		// Check to see what should be imported
+		const toImport = await d20plus.ui.chooseCheckboxList(["Creatures", "Items", "Handouts"], "What to import for this adventure?");
+
+		// monsters
+		const preMonsters = Object.keys(tags)
+			.filter(k => tags[k].page === "bestiary.html")
+			.map(k => tags[k]);
+		if (toImport.includes("Creatures")) doPreImport(preMonsters, showMonsterImport);
+		else doItemImport();
+
+		function showMonsterImport (toImport) {
+			d20plus.ut.log(`Displaying monster import list for [${adMeta.name}]`);
+			d20plus.importer.showImportList(
+				"monster",
+				toImport.filter(it => it),
+				d20plus.monsters.handoutBuilder,
+				{
+					groupOptions: d20plus.monsters._groupOptions,
+					saveIdsTo: RETURNED_IDS,
+					callback: doItemImport,
+					listItemBuilder: d20plus.monsters._listItemBuilder,
+					listIndex: d20plus.monsters._listCols,
+					listIndexConverter: d20plus.monsters._listIndexConverter,
+				},
+			);
+		}
+
+		// items
+		function doItemImport () {
+			const preItems = Object.keys(tags)
+				.filter(k => tags[k].page === "items.html")
+				.map(k => tags[k]);
+			if (toImport.includes("Items")) doPreImport(preItems, showItemImport);
+			else doMainImport();
+		}
+
+		function showItemImport (toImport) {
+			d20plus.ut.log(`Displaying item import list for [${adMeta.name}]`);
+			d20plus.importer.showImportList(
+				"item",
+				toImport.filter(it => it),
+				d20plus.items.handoutBuilder,
+				{
+					groupOptions: d20plus.items._groupOptions,
+					saveIdsTo: RETURNED_IDS,
+					callback: doMainImport,
+					listItemBuilder: d20plus.items._listItemBuilder,
+					listIndex: d20plus.items._listCols,
+					listIndexConverter: d20plus.items._listIndexConverter,
+				},
+			);
+		}
+
+		function doPreImport (asTags, callback) {
+			const tmp = [];
+			let cachedCount = asTags.length;
+			// FIXME crappy inefficient conversion to promise-based version; requires cleanup
+			asTags.forEach(async it => {
+				try {
+					await Renderer.hover.pCacheAndGet(it.page, it.source, it.hash);
+					tmp.push(Renderer.hover.getFromCache(it.page, it.source, it.hash));
+					cachedCount--;
+					if (cachedCount <= 0) callback(tmp);
+				} catch (x) {
+					// eslint-disable-next-line no-console
+					console.log(x);
+					cachedCount--;
+					if (cachedCount <= 0) callback(tmp);
 				}
 			});
+		}
+		/// /////////////////////////////////////////////////////////////////////////////////////////////////////
+		function doMainImport () {
+			// Check to make sure the user wants to import everything
+			if (!toImport.includes("Handouts")) {
+				$("#d20plus-import").dialog("close");
+				return;
+			}
+
+			// pass in any created handouts/characters to use for links in the renderer
+			renderer.setRoll20Ids(RETURNED_IDS);
+
+			let cancelWorker = false;
+			const $btnCancel = $(`#importcancel`);
+			$btnCancel.off("click");
+			$btnCancel.on("click", () => {
+				cancelWorker = true;
+			});
+
+			let remaining = addQueue.length;
+
+			d20plus.ut.log(`Running import of [${adMeta.name}] with ${interval} ms delay between each handout create`);
+			let lastId = null;
+			let lastName = null;
+
+			const worker = setInterval(() => {
+				if (!addQueue.length || cancelWorker) {
+					clearInterval(worker);
+					$stsName.text("DONE!");
+					$stsRemain.text("0");
+					d20plus.ut.log(`Finished import of [${adMeta.name}]`);
+					renderer.resetRoll20Ids();
+					return;
+				}
+
+				// pull items out the queue in LIFO order, for journal ordering (last created will be at the top)
+				const entry = addQueue.pop();
+				entry.name = entry.name || "(Unknown)";
+				entry.name = d20plus.importer.getCleanText(renderer.render(entry.name));
+				$stsName.text(entry.name);
+				$stsRemain.text(remaining--);
+				const folder = d20plus.journal.makeDirTree(entry.dir);
+
+				d20.Campaign.handouts.create({
+					name: entry.name,
+				}, {
+					success: function (handout) {
+						const renderStack = [];
+						renderer.recursiveRender(entry, renderStack);
+						if (lastId && lastName) renderStack.push(`<br><p>Next handout: <a href="http://journal.roll20.net/handout/${lastId}">${lastName}</a></p>`);
+						const rendered = renderStack.join("");
+
+						lastId = handout.id;
+						lastName = entry.name;
+						handout.updateBlobs({notes: rendered});
+						handout.save({notes: (new Date()).getTime(), inplayerjournals: ""});
+						d20.journal.addItemToFolderStructure(handout.id, folder.id);
+					},
+				});
+			}, interval);
+		}
 	};
 }
 

--- a/js/5etools-adventures.js
+++ b/js/5etools-adventures.js
@@ -11,7 +11,7 @@ function d20plusAdventure () {
 	d20plus.adventures.load = function (url) {
 		$("a.ui-tabs-anchor[href='#journal']").trigger("click");
 		DataUtil.loadJSON(url)
-			.then(data => {
+			.then(async data => {
 				function isPart (e) {
 					return typeof e === "string" || (typeof e === "object" && (e.type !== "entries"));
 				}
@@ -91,11 +91,15 @@ function d20plusAdventure () {
 				// storage for returned handout/character IDs
 				const RETURNED_IDS = {};
 
+				// Check to see what should be imported
+				const toImport = await d20plus.ui.chooseCheckboxList(["Creatures", "Items", "Handouts"], "What to import for this adventure?");
+				console.log(toImport);
+
 				// monsters
 				const preMonsters = Object.keys(tags)
 					.filter(k => tags[k].page === "bestiary.html")
 					.map(k => tags[k]);
-				if (confirm("Import creatures from this adventure?")) doPreImport(preMonsters, showMonsterImport);
+				if (toImport.includes("Creatures")) doPreImport(preMonsters, showMonsterImport);
 				else doItemImport();
 
 				function showMonsterImport (toImport) {
@@ -120,7 +124,7 @@ function d20plusAdventure () {
 					const preItems = Object.keys(tags)
 						.filter(k => tags[k].page === "items.html")
 						.map(k => tags[k]);
-					if (confirm("Import items from this adventure?")) doPreImport(preItems, showItemImport);
+					if (toImport.includes("Items")) doPreImport(preItems, showItemImport);
 					else doMainImport();
 				}
 
@@ -161,6 +165,12 @@ function d20plusAdventure () {
 				}
 				/// /////////////////////////////////////////////////////////////////////////////////////////////////////
 				function doMainImport () {
+					// Check to make sure the user wants to import everything
+					if (!toImport.includes("Handouts")) {
+						$("#d20plus-import").dialog("close");
+						return;
+					}
+
 					// pass in any created handouts/characters to use for links in the renderer
 					renderer.setRoll20Ids(RETURNED_IDS);
 


### PR DESCRIPTION
Changed it so that when you import an adventure, it asks you want to import all at once and allows you not to import handouts. Created mostly because I hate that it always imports the handouts whenever I want to test stuff with the adventure importer.