### PR TITLE
fixed how the filter for spell schools works

### DIFF
--- a/js/5etools-spells.js
+++ b/js/5etools-spells.js
@@ -18,7 +18,7 @@ function d20plusSpells () {
 			name: sp.name.toLowerCase(),
 			class: ((sp.classes || {}).fromClassList || (sp.classes || {}).fromClassListVariant || []).map(c => c.name.toLowerCase()),
 			level: Parser.spLevelToFull(sp.level).toLowerCase(),
-			school: sp.school.toLowerCase(),
+			school: Parser.spSchoolAbvToFull(sp.school).toLowerCase(),
 			source: Parser.sourceJsonToAbv(sp.source).toLowerCase(),
 		};
 	};


### PR DESCRIPTION
Made it so that it looks for the name of the school, not the first letter to avoid confusion. If you think it should remain just looking for the first letter, then ignore this PR.