### PR TITLE
made it so that modifying the gmnotes of a handout modifies the import

### DIFF
--- a/js/5etools-main.js
+++ b/js/5etools-main.js
@@ -741,17 +741,16 @@ const betteR205etoolsMain = function () {
 							} else {
 								var id = $hlpr.attr("data-itemid");
 								var handout = d20.Campaign.handouts.get(id);
-								console.log(character);
 								var data = "";
 								if (window.is_gm) {
 									handout._getLatestBlob("gmnotes", function (gmnotes) {
-										data = gmnotes;
+										data = decodeURIComponent(gmnotes);
 										handout.updateBlobs({gmnotes: gmnotes});
 										importData(character, JSON.parse(data), t);
 									});
 								} else {
 									handout._getLatestBlob("notes", function (notes) {
-										data = $(notes).filter("del").html();
+										data = $(decodeURIComponent(notes)).filter("del").html();
 										importData(character, JSON.parse(data), t);
 									});
 								}

--- a/js/5etools-main.js
+++ b/js/5etools-main.js
@@ -742,15 +742,25 @@ const betteR205etoolsMain = function () {
 								var id = $hlpr.attr("data-itemid");
 								var handout = d20.Campaign.handouts.get(id);
 								var data = "";
+
+								// Take a JSON that may be a URI encoded string and return it in non URI format
+								function decodeIfURI (notes) {
+									if (!notes) return "";
+
+									if (notes.charAt(0) == "%") return decodeURIComponent(notes);
+
+									return notes;
+								}
+
 								if (window.is_gm) {
 									handout._getLatestBlob("gmnotes", function (gmnotes) {
-										data = decodeURIComponent(gmnotes);
+										data = decodeIfURI(gmnotes);
 										handout.updateBlobs({gmnotes: gmnotes});
 										importData(character, JSON.parse(data), t);
 									});
 								} else {
 									handout._getLatestBlob("notes", function (notes) {
-										data = $(decodeURIComponent(notes)).filter("del").html();
+										data = $(decodeIfURI(notes)).filter("del").html();
 										importData(character, JSON.parse(data), t);
 									});
 								}


### PR DESCRIPTION
It used to be that if you modified the gmnotes the handout just broke, but now you can drag and drop a modified handout. Note that it only looks at the special `Vetoolscontent` category instead of the main one, which may be confusing, so if you think I should fix that I can, though it's a much larger fix. This also means handouts can't be easily modified for player import, as there is no simple way to access the part of the object.