### PR TITLE
Feature: JS execution in macros

### DIFF
--- a/js/base-chat.js
+++ b/js/base-chat.js
@@ -569,6 +569,18 @@ function baseChat () {
 				"_type": "boolean",
 				"_player": true,
 			},
+			"executeJSMacro": {
+				"name": "Execute JS script in macros",
+				"default": "own",
+				"_type": "_enum",
+				"__values": ["none", "own", "all"],
+				"__texts": [
+					"disabled",
+					"run your own scripts",
+					"run all scripts (only enable this if you trust your GM!)",
+				],
+				"_player": true,
+			},
 		},
 	);
 
@@ -713,6 +725,29 @@ function baseChat () {
 		if (!params[2]) {
 			d20plus.chat.resetSendMyself();
 		}
+		const macroJS = d20plus.cfg.getOrDefault("chat", "executeJSMacro");
+
+		if (macroJS !== "none") {
+			const template = /#(?<macroid>[^ ^#]+)/g;
+			params[0] = params[0].replace(template, (...string) => {
+				const macroId = string.last().macroid;
+				const macroObj = d20plus.ut.getMacroByName(macroId);
+				if (!macroObj) return string[0];
+				const macro = macroObj.attributes.action;
+				const script = d20plus.engine.decodeScript(macro);
+				if (!script) return string[0];
+				if (macroObj.collection.player.id !== d20_player_id && macroJS !== "all") {
+					d20plus.ut.sendHackerChat(`
+						Enable execution for scripts shared by other players
+						(select Execute All in betteR20 options for JS Script).
+						You should do this only if you trust your GM
+					`, true);
+					return "";
+				}
+				return d20plus.engine.runScript(script);
+			});
+		}
+
 		return r20outgoing(...params);
 	}
 
@@ -860,7 +895,13 @@ function baseChat () {
 		d20plus.ut.injectCode(d20.textchat, "incoming", d20plus.chat.r20incoming);
 		d20plus.ut.injectCode(d20.textchat, "doChatInput", d20plus.chat.r20outgoing);
 
-		$(document.body).append(languageTemplate());
+		$(document.body)
+			.append(languageTemplate())
+			.on("click", ".macro > .name", (evt) => {
+				const {currentTarget: target} = evt;
+				d20plus.engine._lastOpenedMacroId = $(target).closest(`[data-macroid]`).data("macroid");
+				d20plus.engine.enhanceMacros();
+			});
 		availableLanguagesPlayer(d20_player_id);
 		buildLanguageIndex();
 

--- a/js/base-chat.js
+++ b/js/base-chat.js
@@ -575,9 +575,9 @@ function baseChat () {
 				"_type": "_enum",
 				"__values": ["none", "own", "all"],
 				"__texts": [
-					"disabled",
-					"run your own scripts",
-					"run all scripts (only enable this if you trust your GM!)",
+					"Disabled",
+					"Run your own scripts",
+					"Run all scripts (only if you trust your GM!)",
 				],
 				"_player": true,
 			},
@@ -729,13 +729,13 @@ function baseChat () {
 
 		if (macroJS !== "none") {
 			const template = /#(?<macroid>[^ ^#]+)/g;
-			params[0] = params[0].replace(template, (...string) => {
-				const macroId = string.last().macroid;
+			params[0] = params[0].replace(template, (...match) => {
+				const macroId = match.last().macroid;
 				const macroObj = d20plus.ut.getMacroByName(macroId);
-				if (!macroObj) return string[0];
+				if (!macroObj) return match[0];
 				const macro = macroObj.attributes.action;
 				const script = d20plus.engine.decodeScript(macro);
-				if (!script) return string[0];
+				if (!script) return match[0];
 				if (macroObj.collection.player.id !== d20_player_id && macroJS !== "all") {
 					d20plus.ut.sendHackerChat(`
 						Enable execution for scripts shared by other players
@@ -744,7 +744,7 @@ function baseChat () {
 					`, true);
 					return "";
 				}
-				return d20plus.engine.runScript(script);
+				return d20plus.engine.runScript(script, macroObj);
 			});
 		}
 
@@ -899,8 +899,8 @@ function baseChat () {
 			.append(languageTemplate())
 			.on("click", ".macro > .name", (evt) => {
 				const {currentTarget: target} = evt;
-				d20plus.engine._lastOpenedMacroId = $(target).closest(`[data-macroid]`).data("macroid");
-				d20plus.engine.enhanceMacros();
+				const openedMacroId = $(target).closest(`[data-macroid]`).data("macroid");
+				d20plus.engine.enhanceMacros(openedMacroId);
 			});
 		availableLanguagesPlayer(d20_player_id);
 		buildLanguageIndex();

--- a/js/base-config.js
+++ b/js/base-config.js
@@ -605,7 +605,10 @@ function baseConfig () {
 							break;
 						}
 						case "_enum": { // for generic String enums not covered above
-							const $field = $(`<select id="conf_field_${idx}" class="cfg_grp_${cfgK}" data-item="${grpK}">${d20plus.cfg.getCfgEnumVals(cfgK, grpK).map(it => `<option value="${it}">${it}</option>`)}</select>`);
+							const texts = CONFIG_OPTIONS[cfgK][grpK]?.__texts;
+							const $field = $(`<select id="conf_field_${idx}" class="cfg_grp_${cfgK}" data-item="${grpK}">${d20plus.cfg.getCfgEnumVals(cfgK, grpK).map((it, i) => {
+								return `<option value="${it}">${texts ? texts[i] : it}</option>`
+							})}</select>`);
 
 							const cur = d20plus.cfg.get(cfgK, grpK);
 							if (cur !== undefined) {

--- a/js/base-css.js
+++ b/js/base-css.js
@@ -611,6 +611,19 @@ function baseCss () {
 			s: `#page-toolbar`,
 			r: `display: block;`,
 		},
+		// Macro editor styles
+		{
+			s: `.jsdialog .actionhelp.r20, .jsdialog .commandhelp.r20`,
+			r: `display: none;`,
+		},
+		{
+			s: `.jsdialog .actionhelp.js, .jsdialog .commandhelp.js`,
+			r: `display: inline-block;`,
+		},
+		{
+			s: `.actionhelp.js, .commandhelp.js`,
+			r: `display: none;`,
+		},
 	];
 
 	d20plus.css.baseCssRulesPlayer = [

--- a/js/base-engine.js
+++ b/js/base-engine.js
@@ -204,39 +204,45 @@ function d20plusEngine () {
 		});
 	};
 
-	d20plus.engine.enhanceMacros = () => {
-		const $dialog = $(`.dialog[data-macroid=${d20plus.engine._lastOpenedMacroId}]`);
-		if (!d20plus.engine._lastOpenedMacroId || !$dialog[0]) return;
+	d20plus.engine.enhanceMacros = (openedMacroId) => {
+		const $dialog = $(`.dialog[data-macroid=${openedMacroId}]`);
+		if (!openedMacroId || !$dialog[0]) return;
 		const $macro = $dialog.find(`.macro.tokenizer`);
+		const $b20macro = $dialog.find(`.tokenizer.b20`);
 		const $name = $dialog.find("input.name");
 		const $checkbox = $dialog.find(".isjs")
-			.on("change", (evt) => {
-				if ($(evt.target).prop("checked")) $macro.parent().addClass("jsdialog");
+			.on("change", () => {
+				if ($checkbox.prop("checked")) $macro.parent().addClass("jsdialog");
 				else $macro.parent().removeClass("jsdialog");
 			});
+		const macro = currentPlayer.macros._byId[openedMacroId];
 		const script = d20plus.engine.decodeScript($macro.val());
 		if (script) {
 			$macro.parent().addClass("jsdialog");
-			$macro.val(script);
+			$b20macro.val(script);
 			$checkbox.prop("checked", true);
+		} else {
+			$b20macro.val($macro.val());
 		}
 		$dialog.find(".btn.testmacro").on("click", () => {
-			if (!$checkbox.prop("checked")) return;
-			const script = $macro.val();
-			$macro.val(d20plus.engine.runScript(script));
-			setTimeout(() => $macro.val(script), 100);
+			if (!$checkbox.prop("checked")) {
+				$macro.val($b20macro.val());
+			} else {
+				$macro.val(d20plus.engine.runScript($b20macro.val(), macro));
+			}
 		});
 		const $buttons = $dialog.parent()
 			.find(".ui-dialog-buttonpane button:not(.active)")
 			.addClass("active");
-		$buttons.on("mouseup", (evt) => {
-			if (!$name.val()) {
-				let i = 0;
-				while (d20plus.ut.getMacroByName(`Untitled${i}`)) i++;
-				$name.val(`Untitled${i}`);
-			}
-			if (!$checkbox.prop("checked") || evt.which !== 1) return;
-			$macro.val(d20plus.engine.encodeScript($macro.val()));
+		$buttons.on("mouseup", () => {
+			let name = $name.val() || "Untitled";
+			const existing = d20.Campaign.players.map(p => p.macros
+				.filter(m => m.id !== openedMacroId && (p.id === d20_player_id || m.visibleToCurrentPlayer()))
+				.map(m => m.get("name"))).flat();
+			while (existing.includes(name)) name = name.replace(/(\d*?)$/, id => 1 * id + 1);
+			if ($name.val() !== name) $name.val(name);
+			if (!$checkbox.prop("checked")) $macro.val($b20macro.val());
+			else $macro.val(d20plus.engine.encodeScript($b20macro.val()));
 		});
 	}
 
@@ -254,13 +260,12 @@ function d20plusEngine () {
 		return `bs\`\`<\`\`...${saved}...\`\`>\`\``;
 	}
 
-	d20plus.engine.runScript = (script) => {
-		const vuln = /\b(XMLHttpRequest|eval|Function|document|window|Window)\b/g;
-		const insecure = script.replace(vuln, str => str.replace("o", "о").replace("e", "е"));
-		const toRun = `"use ${"strict"}";\n${insecure}`;
+	d20plus.engine.runScript = (script, macro) => {
+		const fnBody = `"use ${"strict"}";\n${script}`;
 		try {
 			// eslint-disable-next-line no-new-func
-			return Function(toRun)() || "";
+			const fn = new Function(fnBody);
+			return fn.call(macro) || "";
 		} catch (e) {
 			d20plus.ut.sendHackerChat(`Script executed with errors`, true);
 			d20plus.ut.error(e);

--- a/js/base-engine.js
+++ b/js/base-engine.js
@@ -236,10 +236,10 @@ function d20plusEngine () {
 			.addClass("active");
 		$buttons.on("mouseup", () => {
 			let name = $name.val() || "Untitled";
-			const existing = d20.Campaign.players.map(p => p.macros
+			const existing = new Set(d20.Campaign.players.map(p => p.macros
 				.filter(m => m.id !== openedMacroId && (p.id === d20_player_id || m.visibleToCurrentPlayer()))
-				.map(m => m.get("name"))).flat();
-			while (existing.includes(name)) name = name.replace(/(\d*?)$/, id => 1 * id + 1);
+				.map(m => m.get("name"))).flat());
+			while (existing.has(name)) name = name.replace(/(\d*?)$/, id => Number(id) + 1);
 			if ($name.val() !== name) $name.val(name);
 			if (!$checkbox.prop("checked")) $macro.val($b20macro.val());
 			else $macro.val(d20plus.engine.encodeScript($b20macro.val()));
@@ -261,7 +261,8 @@ function d20plusEngine () {
 	}
 
 	d20plus.engine.runScript = (script, macro) => {
-		const fnBody = `"use ${"strict"}";\n${script}`;
+		// b20 fails to load if it has words use and strict separated by space ANYWHERE (right, even in comments)
+		const fnBody = `"use\u0020strict";\n${script}`;
 		try {
 			// eslint-disable-next-line no-new-func
 			const fn = new Function(fnBody);

--- a/js/templates/template-roll20-editors-misc.js
+++ b/js/templates/template-roll20-editors-misc.js
@@ -489,6 +489,63 @@ function initHTMLroll20EditorsMisc () {
 		</div>
 	</script>
 	`;
+
+	d20plus.html.macroEditor = `
+	<script id="tmpl_macroeditor" type="text/html">
+		<div>
+			<label>
+				Name
+				<span style='color: #777;'> (Don't include the <code>#</code> or spaces in the name)</span>
+			</label>
+			<input class='name' type='text'>
+			<div class='clear'></div>
+			<!-- BEGIN MOD -->
+			<label>
+				Actions
+				<span class='actionhelp r20' style='color: #777;'>&nbsp;(One command/roll per line)</span>
+				<span class='actionhelp js' style='color: #777;'>&nbsp;(Regular javascript commands)</span>
+			</label>
+			<textarea class='macro tokenizer' style='width: 100%; min-height: 75px; margin-top: 5px;'></textarea>
+			<div class='clear'></div>
+			<div class='btn testmacro' style='float: right;'>Test Macro</div>
+			<p class='commandhelp r20' style='color: #777;'>
+				Type <code>@</code> to insert variables from Characters
+				<br>
+				Type <code>#</code> to insert other macros
+			</p>
+			<p class='commandhelp js' style='color: #777;'>
+				JS <code>strict</code> mode directive is enabled
+				<br>
+				JS <code>#macro</code> can't be nested in other macros
+				<br>
+				Type <code>return</code> to output results to chat
+			</p>
+			<div class='clear'></div>
+			<label>
+				<input class='isjs' style='margin-right: 10px;' type='checkbox' value='1'>Execute as JS userscript</input>
+			</label>
+			<!-- END MOD -->
+			<label>
+				<input class='istokenaction' style='margin-right: 10px;' type='checkbox' value='1'>Show as Token Action?</input>
+			</label>
+			<div class='clear' style='height: 15px;'></div>
+			<$ if(window.is_gm) { $>
+			<label>
+				Visible To Players
+				<span style='color: #777;'>(Optional)</span>
+			</label>
+			<select class='visibleto chosen' multiple='true' style='width: 100%;'>
+				<option value='all'>All Players</option>
+				<$ window.Campaign.players.each(function(player) { $>
+				<option value="<$!player.id$>"><$!player.get("displayname")$></option>
+				<$ }); $>
+			</select>
+			<div class='clear'></div>
+			<$ } $>
+			<button class='btn btn-danger delete'>Delete Macro</button>
+		</div>
+	</script>
+	`;
 }
 
 SCRIPT_EXTENSIONS.push(initHTMLroll20EditorsMisc);

--- a/js/templates/template-roll20-editors-misc.js
+++ b/js/templates/template-roll20-editors-misc.js
@@ -503,9 +503,21 @@ function initHTMLroll20EditorsMisc () {
 			<label>
 				Actions
 				<span class='actionhelp r20' style='color: #777;'>&nbsp;(One command/roll per line)</span>
-				<span class='actionhelp js' style='color: #777;'>&nbsp;(Regular javascript commands)</span>
+				<span class='actionhelp js' style='color: #777;'>
+					&nbsp;(Regular javascript commands)
+					&nbsp;<a class="tipsy-n-right showtip pictos" original-title="<div style='background:black;width:300px;margin:-5px;padding:5px;text-align:left'>
+				<strong>Notes on JS code usage:</strong><br>
+				<code>use&nbsp;strict</code> directive enabled<br>
+				<code>this</code> refers to this r20 macro object<br>
+				<code>d20</code> object can be used to access game data:<br>
+				<code>.textchat.doChatInput()</code> sends text to chat<br>
+				<code>.engine.selected()</code> gets selected tokens<br>
+				<code>.Campaign.activePage()</code> gets current map<br>
+			</div>">?</a>
+				</span>
 			</label>
-			<textarea class='macro tokenizer' style='width: 100%; min-height: 75px; margin-top: 5px;'></textarea>
+			<textarea class='macro tokenizer' style='display:none'></textarea>
+			<textarea class='tokenizer b20' style='width: 100%; min-height: 75px; margin-top: 5px'></textarea>
 			<div class='clear'></div>
 			<div class='btn testmacro' style='float: right;'>Test Macro</div>
 			<p class='commandhelp r20' style='color: #777;'>
@@ -514,9 +526,7 @@ function initHTMLroll20EditorsMisc () {
 				Type <code>#</code> to insert other macros
 			</p>
 			<p class='commandhelp js' style='color: #777;'>
-				JS <code>strict</code> mode directive is enabled
-				<br>
-				JS <code>#macro</code> can't be nested in other macros
+				This <code>#macro</code> can't be nested in macros or actions
 				<br>
 				Type <code>return</code> to output results to chat
 			</p>


### PR DESCRIPTION
Macro editor can be switched to script mode, in which users can write their own JS code. It can do almost anything, access d20 object etc. It can't replace native APIs, but it still can do a lot of things impossible with native roll20 macros.

New config dropdown added, with the following options:
- to disable JS execution completely (obfuscated code will be sent to chat as is)
- to enable JS execution for user's own scripts
- to enable JS execution for all scripts, including those shared by the GM

JS scripts can be tested right from the macro editor regardless of JS execution setting. Also now user can't create macro with empty or duplicate name.
![js-macro](https://user-images.githubusercontent.com/76915580/230742669-54667a53-2d18-44fb-a1fd-9f8544d33d2f.gif)
