### PR TITLE
Fix: DL, actions, page settings

### DIFF
--- a/js/base-config.js
+++ b/js/base-config.js
@@ -752,6 +752,16 @@ function baseConfig () {
 		}
 	}
 
+	d20plus.cfg.HandleCss = () => {
+		// properly align layer toolbar
+		const $wrpDmModeSw = $(`.dark-mode-switch`);
+		const $wrpBtnsMain = $(`#floatingtoolbar`);
+		const $ulBtns = $(`#floatinglayerbar`);
+		const darkModeShift = $wrpDmModeSw.css("display") === "none" || $wrpDmModeSw.css("visibility") === "hidden" ? 0 : 54;
+		$ulBtns.css({top: $wrpBtnsMain.height() + darkModeShift + 40});
+		$wrpDmModeSw.css({top: $wrpBtnsMain.height() + 40});
+	}
+
 	d20plus.cfg.baseHandleConfigChange = () => {
 		d20plus.cfg.handleInitiativeShrink();
 
@@ -767,6 +777,8 @@ function baseConfig () {
 		$(`.dark-mode-switch`).toggle(!d20plus.cfg.get("interface", "hideDarkModeSwitch"));
 		$(`#helpsite`).toggle(!d20plus.cfg.getOrDefault("interface", "hideHelpButton"));
 		$(`#langpanel`).toggle(d20plus.cfg.getOrDefault("chat", "languages"));
+
+		d20plus.cfg.HandleCss();
 	};
 
 	d20plus.cfg.startPlayerConfigHandler = () => {

--- a/js/base-css.js
+++ b/js/base-css.js
@@ -624,6 +624,15 @@ function baseCss () {
 			s: `.actionhelp.js, .commandhelp.js`,
 			r: `display: none;`,
 		},
+		// Deck editor styles
+		{
+			s: `tr.card:hover::after`,
+			r: `background: rgba(200, 200, 200, 0.4);`,
+		},
+		{
+			s: `tr.card::after`,
+			r: `content: "D";font-family: pictos;display: block;float: right;padding: 3px;border-radius: 5px;background: var(--dark-primary);margin: 10px 3px;`,
+		},
 	];
 
 	d20plus.css.baseCssRulesPlayer = [

--- a/js/base-engine.js
+++ b/js/base-engine.js
@@ -130,6 +130,7 @@ function d20plusEngine () {
 		$("#tmpl_handouteditor").html($(d20plus.html.handoutEditor).html());
 		$("#tmpl_deckeditor").html($(d20plus.html.deckEditor).html());
 		$("#tmpl_cardeditor").html($(d20plus.html.cardEditor).html());
+		$("#tmpl_cardupload").html($(d20plus.html.cardUploader).html());
 		$("#tmpl_macroeditor").html($(d20plus.html.macroEditor).html());
 		// ensure tokens have editable sight
 		$("#tmpl_tokeneditor").replaceWith(d20plus.html.tokenEditor);

--- a/js/base-engine.js
+++ b/js/base-engine.js
@@ -387,6 +387,9 @@ function d20plusEngine () {
 		width: {id: "page-size-width-input", class: ".width.units.page_setting_item"},
 		height: {id: "page-size-height-input", class: ".height.units.page_setting_item"},
 		background_color: {class: ".pagebackground"},
+		wrapperColor: {class: ".wrappercolor"},
+		useAutoWrapper: {id: "page-wrapper-color-from-map-toggle", class: ".useautowrapper"},
+
 		scale_number: {id: "page-size-height-input", class: ".scale_number"},
 		scale_units: {id: "page-scale-grid-cell-label-select", class: ".scale_units"},
 		gridlabels: {id: "page-grid-hex-label-toggle", class: ".gridlabels"},
@@ -810,7 +813,9 @@ function d20plusEngine () {
 		}
 
 		d20.engine.canvas._renderAll = _.bind(d20plus.mod.renderAll, d20.engine.canvas);
-		d20.engine.canvas._layerIteratorGenerator = d20plus.mod.layerIteratorGenerator;
+		d20.engine.canvas.sortTokens = _.bind(d20plus.mod.sortTokens, d20.engine.canvas);
+		d20.engine.canvas.drawAnyLayer = _.bind(d20plus.mod.drawAnyLayer, d20.engine.canvas);
+		d20.engine.canvas.drawTokensWithoutAuras = _.bind(d20plus.mod.drawTokensWithoutAuras, d20.engine.canvas);
 	};
 
 	d20plus.engine.removeLinkConfirmation = function () {

--- a/js/base-mod.js
+++ b/js/base-mod.js
@@ -4,24 +4,30 @@
 function d20plusMod () {
 	d20plus.mod = {};
 
-	d20plus.mod.setMode = function (t) {
-		d20plus.ut.log(`Setting mode ${t}`);
-		const preserveDrawingColor = (stash) => {
-			const drawingTools = ["rect", "ellipse", "text", "path", "polygon"];
-			const drawingProps = [{nm: "fill", el: "fillcolor"}, {nm: "color", el: "strokecolor"}];
+	d20plus.mod.preserveDrawingColor = (() => {
+		const drawingTools = ["rect", "ellipse", "text", "path", "polygon"];
+		const drawingProps = [{nm: "fill", el: "fillcolor"}, {nm: "color", el: "strokecolor"}];
+		return (t) => {
 			if (!drawingTools.includes(t)) return;
 			drawingProps.forEach(prop => {
-				if (stash) d20plus.mod[`drawing${prop.nm}`] = d20.engine.canvas.freeDrawingBrush[prop.nm];
-				else {
-					if (d20plus.mod[`drawingcolor`] === "rgb(0, 0, 0)" || !d20plus.mod[`drawingcolor`]) return;
-					$(`#path_${prop.el}`).val(d20plus.mod[`drawing${prop.nm}`]).trigger("change");
+				if (!prop.stashed) {
+					prop.stashed = true;
+					prop.value = d20.engine.canvas.freeDrawingBrush[prop.nm];
+				} else {
+					prop.stashed = false;
+					if (drawingProps[1].value === "rgb(0, 0, 0)" || !drawingProps[1].value) return;
+					$(`#path_${prop.el}`).val(prop.value).trigger("change");
 				}
 			});
 		}
+	})();
+
+	d20plus.mod.setMode = function (t) {
+		d20plus.ut.log(`Setting mode ${t}`);
 		try {
-			preserveDrawingColor(true);
+			d20plus.mod.preserveDrawingColor(t);
 			d20.Campaign.activePage().setModeRef(t);
-			preserveDrawingColor();
+			d20plus.mod.preserveDrawingColor(t);
 		} catch (e) {
 			d20plus.ut.log(`Switching using legacy because ${e.message}`);
 			d20plus.mod.setModeLegacy(t);

--- a/js/base-ui.js
+++ b/js/base-ui.js
@@ -77,7 +77,7 @@ function baseUi () {
 			.css({
 				width: 30,
 				position: "absolute",
-				left: 20,
+				left: 10,
 				top: $wrpBtnsMain.height() + 90,
 				border: "1px solid #666",
 				boxShadow: "1px 1px 3px #666",

--- a/js/header.js
+++ b/js/header.js
@@ -29,6 +29,7 @@ addConfigOptions = function (category, options) {
 };
 
 OBJECT_DEFINE_PROPERTY = Object.defineProperty;
+OBJECT_DEFINED_COUNT = 0;
 ACCOUNT_ORIGINAL_PERMS = {
 	isPro: false,
 	largefeats: false,
@@ -39,8 +40,10 @@ Object.defineProperty = function (obj, prop, vals) {
 		if (prop === "largefeats" || prop === "xlfeats" || prop === "isPro") {
 			ACCOUNT_ORIGINAL_PERMS[prop] = vals.value;
 			vals.value = true;
+			OBJECT_DEFINED_COUNT++;
 		}
-		OBJECT_DEFINE_PROPERTY(obj, prop, vals);
+		OBJECT_DEFINE_PROPERTY.bind(Object)(obj, prop, vals);
+		if (OBJECT_DEFINED_COUNT === 3) Object.defineProperty = OBJECT_DEFINE_PROPERTY.bind(Object);
 	} catch (e) {
 		// eslint-disable-next-line no-console
 		console.log("failed to define property:", e, obj, prop, vals);

--- a/js/header.js
+++ b/js/header.js
@@ -28,27 +28,20 @@ addConfigOptions = function (category, options) {
 	else CONFIG_OPTIONS[category] = Object.assign(CONFIG_OPTIONS[category], options);
 };
 
-OBJECT_DEFINE_PROPERTY = Object.defineProperty;
-OBJECT_DEFINED_COUNT = 0;
+// Grant PRO features to every user
+OBJECT_DEFINE_PROPERTY = Object.defineProperty.bind(Object);
 ACCOUNT_ORIGINAL_PERMS = {
 	isPro: false,
 	largefeats: false,
 	xlfeats: false,
 };
 Object.defineProperty = function (obj, prop, vals) {
-	try {
-		if (prop === "largefeats" || prop === "xlfeats" || prop === "isPro") {
-			ACCOUNT_ORIGINAL_PERMS[prop] = vals.value;
-			vals.value = true;
-			OBJECT_DEFINED_COUNT++;
-		}
-		OBJECT_DEFINE_PROPERTY.bind(Object)(obj, prop, vals);
-		if (OBJECT_DEFINED_COUNT === 3) Object.defineProperty = OBJECT_DEFINE_PROPERTY.bind(Object);
-	} catch (e) {
-		// eslint-disable-next-line no-console
-		console.log("failed to define property:", e, obj, prop, vals);
+	if (prop === "largefeats" || prop === "xlfeats" || prop === "isPro") {
+		ACCOUNT_ORIGINAL_PERMS[prop] = vals.value;
+		vals.value = true;
 	}
-}; // */
+	return OBJECT_DEFINE_PROPERTY(obj, prop, vals);
+};
 
 FINAL_CANVAS_MOUSEDOWN_LIST = [];
 FINAL_CANVAS_MOUSEMOVE_LIST = [];

--- a/js/header.js
+++ b/js/header.js
@@ -28,15 +28,15 @@ addConfigOptions = function (category, options) {
 	else CONFIG_OPTIONS[category] = Object.assign(CONFIG_OPTIONS[category], options);
 };
 
-//OBJECT_DEFINE_PROPERTY = Object.defineProperty; // FIXME(165) re-enable when we have a better solution
+OBJECT_DEFINE_PROPERTY = Object.defineProperty;
 ACCOUNT_ORIGINAL_PERMS = {
+	isPro: false,
 	largefeats: false,
 	xlfeats: false,
 };
-/* Disabled temporarily due to breaking better20 // FIXME(165) re-enable when we have a better solution
 Object.defineProperty = function (obj, prop, vals) {
 	try {
-		if (prop === "largefeats" || prop === "xlfeats") {
+		if (prop === "largefeats" || prop === "xlfeats" || prop === "isPro") {
 			ACCOUNT_ORIGINAL_PERMS[prop] = vals.value;
 			vals.value = true;
 		}
@@ -45,8 +45,7 @@ Object.defineProperty = function (obj, prop, vals) {
 		// eslint-disable-next-line no-console
 		console.log("failed to define property:", e, obj, prop, vals);
 	}
-};
-*/
+}; // */
 
 FINAL_CANVAS_MOUSEDOWN_LIST = [];
 FINAL_CANVAS_MOUSEMOVE_LIST = [];

--- a/js/templates/template-roll20-actions-menu.js
+++ b/js/templates/template-roll20-actions-menu.js
@@ -104,11 +104,15 @@ function initHTMLroll20actionsMenu () {
 					<ul class='submenu' data-menuname='positioning'>
 						<li data-action-type="tolayer_map" class='<$ if(this && this.get && this.get("layer") == "map") { $>active<$ } $>'><span class="pictos ctx__layer-icon">@</span> Map Layer</li>
 						<!-- BEGIN MOD -->
+						<$ if(this?.get && this.get("layer") == "background" || d20plus.cfg.getOrDefault("canvas", "showBackground")) { $>
 						<li data-action-type="tolayer_background" class='<$ if(this && this.get && this.get("layer") == "background") { $>active<$ } $>'><span class="pictos ctx__layer-icon">a</span> Background Layer</li>
+						<$ } $>
 						<!-- END MOD -->
 						<li data-action-type="tolayer_objects" class='<$ if(this && this.get && this.get("layer") == "objects") { $>active<$ } $>'><span class="pictos ctx__layer-icon">b</span> Token Layer</li>
 						<!-- BEGIN MOD -->
+						<$ if(this?.get && this.get("layer") == "foreground" || d20plus.cfg.getOrDefault("canvas", "showForeground")) { $>
 						<li data-action-type="tolayer_foreground" class='<$ if(this && this.get && this.get("layer") == "foreground") { $>active<$ } $>'><span class="pictos ctx__layer-icon">B</span> Foreground Layer</li>
+						<$ } $>
 						<!-- END MOD -->
 						<li data-action-type="tolayer_gmlayer" class='<$ if(this && this.get && this.get("layer") == "gmlayer") { $>active<$ } $>'><span class="pictos ctx__layer-icon">E</span> GM Layer</li>
 						<li data-action-type="tolayer_walls" class='<$ if(this && this.get && this.get("layer") == "walls") { $>active<$ } $>'><span class="pictostwo ctx__layer-icon">r</span> Lighting Layer</li>

--- a/js/templates/template-roll20-editors-misc.js
+++ b/js/templates/template-roll20-editors-misc.js
@@ -253,175 +253,217 @@ function initHTMLroll20EditorsMisc () {
 	`;
 
 	d20plus.html.deckEditor = `
-	<script id='tmpl_deckeditor' type='text/html'>
-		<div class='dialog largedialog deckeditor' style='display: block;'>
+	<script id="tmpl_deckeditor" type="text/html">
+		<div class="dialog largedialog deckeditor" style="display: block;">
 			<label>Name</label>
-			<input class='name' type='text'>
-			<div class='clear' style='height: 14px;'></div>
+			<input class="name" type="text" />
+			<div class="clear" style="height: 14px;"></div>
 			<label>
-				<input class='showplayers' type='checkbox'>
+				<input class="showplayers" type="checkbox" />
 				Show deck to players?
 			</label>
-			<div class='clear' style='height: 7px;'></div>
+			<div class="clear" style="height: 7px;"></div>
 			<label>
-				<input class='playerscandraw' type='checkbox'>
+				<input class="showtooltips" type="checkbox" />
+				Show card tooltips?
+			</label>
+			<div class="clear" style="height: 7px;"></div>
+			<label>
+				<input class="playerscandraw" type="checkbox" />
 				Players can draw cards?
 			</label>
-			<div class='clear' style='height: 7px;'></div>
+			<div class="clear" style="height: 7px;"></div>
 			<label>
-				<input class='infinitecards' type='checkbox'>
+				<input class="infinitecards" type="checkbox" />
 				Cards in deck are infinite?
 			</label>
-			<p class='infinitecardstype'>
+			<p class="infinitecardstype">
+				<$ var deckId = this.get('id'); $>
+				<$ var deckInfiniteTypeName = \`\${deckId}infinitecardstype\`; $>
 				<label>
-					<input name='infinitecardstype' type='radio' value='random'>
+					<input type="radio" name="<$! deckInfiniteTypeName $>" value="random" />
 					Always a random card
 				</label>
 				<label>
-					<input name='infinitecardstype' type='radio' value='cycle'>
+					<input type="radio" name="<$! deckInfiniteTypeName $>" value="cycle" />
 					Draw through deck, shuffle, repeat
 				</label>
 			</p>
-			<div class='clear' style='height: 7px;'></div>
+			<div class="clear" style="height: 7px;"></div>
 			<label>
 				Allow choosing specific cards from deck:
-				<select class='deckpilemode'>
-					<option value='none'>Disabled</option>
-					<option value='choosebacks_gm'>GM Choose: Show Backs</option>
-					<option value='choosefronts_gm'>GM Choose: Show Fronts</option>
-					<option value='choosebacks'>GM + Players Choose: Show Backs</option>
-					<option value='choosefronts'>GM + Players Choose: Show Fronts</option>
+				<br>
+				<select class="deckpilemode">
+					<option value="none">Disabled</option>
+					<option value="choosebacks_gm">GM Choose: Show Backs</option>
+					<option value="choosefronts_gm">GM Choose: Show Fronts</option>
+					<option value="choosebacks">GM + Players Choose: Show Backs</option>
+					<option value="choosefronts">GM + Players Choose: Show Fronts</option>
 				</select>
 			</label>
-			<div class='clear' style='height: 7px;'></div>
+			<div class="clear" style="height: 7px;"></div>
 			<label>
 				Discard Pile:
-				<select class='discardpilemode'>
-					<option value='none'>No discard pile</option>
-					<option value='choosebacks'>Choose: Show Backs</option>
-					<option value='choosefronts'>Choose: Show Fronts</option>
-					<option value='drawtop'>Draw most recent/top card</option>
-					<option value='drawbottom'>Draw oldest/bottom card</option>
+				<br>
+				<select class="discardpilemode">
+					<option value="none">No discard pile</option>
+					<option value="choosebacks">Choose: Show Backs</option>
+					<option value="choosefronts">Choose: Show Fronts</option>
+					<option value="drawtop">Draw most recent/top card</option>
+					<option value="drawbottom">Draw oldest/bottom card</option>
 				</select>
 			</label>
-			<div class='clear' style='height: 7px;'></div>
-			<hr>
+			<div class="clear" style="height: 7px;"></div>
+			<label>
+				Removed Cards Pile:
+				<br>
+				<select class="removedcardsmode">
+					<option value="none">No Removed Cards Pile</option>
+					<option value="choosebacks">Choose: Show Backs</option>
+					<option value="choosefronts">Choose: Show Fronts</option>
+				</select>
+			</label>
+			<div class="clear" style="height: 7px;"></div>
+			<hr />
 			<strong>When played to the tabletop...</strong>
-			<div class='clear' style='height: 5px;'></div>
+			<div class="clear" style="height: 5px;"></div>
 			<label>
 				Played Facing:
-				<select class='cardsplayed' style='display: inline-block; width: auto; position: relative; top: 3px;'>
-					<option value='facedown'>Face Down</option>
-					<option value='faceup'>Face Up</option>
+				<select class="cardsplayed" style="display: inline-block; width: auto; position: relative; top: 3px;">
+					<option value="facedown">Face Down</option>
+					<option value="faceup">Face Up</option>
 				</select>
 			</label>
-			<div class='clear' style='height: 7px;'></div>
+			<div class="clear" style="height: 7px;"></div>
 			<label>
 				Considered:
-				<select class='treatasdrawing' style='display: inline-block; width: auto; position: relative; top: 3px;'>
-					<option value='true'>Drawings (No Bubbles/Stats)</option>
-					<option value='false'>Tokens (Including Bubbles and Stats)</option>
+				<select class="treatasdrawing" style="display: inline-block; width: auto; position: relative; top: 3px;">
+					<option value="true">Drawings (No Bubbles/Stats)</option>
+					<option value="false">Tokens (Including Bubbles and Stats)</option>
 				</select>
 			</label>
-			<div class='clear' style='height: 7px;'></div>
-			<div class='inlineinputs'>
+			<div class="clear" style="height: 7px;"></div>
+			<div class="inlineinputs">
 				Card Size:
-				<input class='defaultwidth' type='text'>
+				<input class="defaultwidth" type="text" />
 				x
-				<input class='defaultheight' type='text'>
+				<input class="defaultheight" type="text" />
 				px
 			</div>
-			<small style='text-align: left; padding-left: 135px; width: auto;'>Leave blank for default auto-sizing</small>
-			<div class='clear' style='height: 7px;'></div>
-			<!-- %label -->
-			<!-- %input.showalldrawn(type="checkbox") -->
-			<!-- Everyone sees what card is drawn onto top of deck? -->
-			<!-- .clear(style="height: 7px;") -->
-			<hr>
+			<small style="text-align: left; padding-left: 135px; width: auto;">Leave blank for default auto-sizing</small>
+			<div class="clear" style="height: 7px;"></div>
+			<hr />
 			<strong>In other's hands...</strong>
-			<div class='clear' style='height: 5px;'></div>
-			<div class='inlineinputs'>
-				<label style='width: 75px;'>Players see:</label>
+			<div class="clear" style="height: 5px;"></div>
+			<div class="inlineinputs">
+				<label style="width: 75px;"> Players see:</label>
 				<label>
-					<input class='players_seenumcards' type='checkbox'>
+					<input class="players_seenumcards" type="checkbox" />
 					Number of Cards
 				</label>
 				<label>
-					<input class='players_seefrontofcards' type='checkbox'>
+					<input class="players_seefrontofcards" type="checkbox" />
 					Front of Cards
 				</label>
 			</div>
-			<div class='clear' style='height: 5px;'></div>
-			<div class='inlineinputs'>
-				<label style='width: 75px;'>GM sees:</label>
+			<div class="clear" style="height: 5px;"></div>
+			<div class="inlineinputs">
+				<label style="width: 75px;">GM sees:</label>
 				<label>
-					<input class='gm_seenumcards' type='checkbox'>
+					<input class="gm_seenumcards" type="checkbox" />
 					Number of Cards
 				</label>
 				<label>
-					<input class='gm_seefrontofcards' type='checkbox'>
+					<input class="gm_seefrontofcards" type="checkbox" />
 					Front of Cards
 				</label>
 			</div>
-			<div class='clear' style='height: 5px;'></div>
-			<hr>
-			<!-- BEGIN MOD -->
-			<button class='btn deck-mass-cards-by-url' style='float: right; margin-left: 5px;' data-deck-id="<$!this.id$>">
-				Add Cards from URLs
+			<div class="clear" style="height: 5px;"></div>
+			<hr />
+			<button class="addmultiplecards btn" style="float: right;">
+				<span class="pictos">&</span>
+				Add Multiple
 			</button>
-			<!-- END MOD -->
-			<button class='addcard btn' style='float: right;'>
-				<span class='pictos'>&</span>
+			<button class="addcard btn" style="float: right;">
+				<span class="pictos">&</span>
 				Add Card
 			</button>
 			<h3>Cards</h3>
-			<div class='clear' style='height: 7px;'></div>
-			<table class='table table-striped'>
+			<div class="clear" style="height: 7px;"></div>
+			<table class="table table-striped">
 				<tbody></tbody>
 			</table>
-			<div class='clear' style='height: 15px;'></div>
+			<div class="clear" style="height: 15px;"></div>
 			<label>
 				<strong>Card Backing (Required)</strong>
 			</label>
-			<div class='clear' style='height: 7px;'></div>
+			<div class="clear" style="height: 7px;"></div>
 			<!-- BEGIN MOD -->
 			<button class='btn deck-image-by-url' style="margin-bottom: 10px" data-deck-id="<$!this.id$>">Set image from URL...</button>
 			<!-- END MOD -->
-			<div class="avatar dropbox <$! this.get("avatar") != "" ? "filled" : "" $>">
-				<div class='status'></div>
-				<div class='inner'></div>
-				<$ if(this.get("avatar") == "") { $>
-				<h4 style='padding-bottom: 0px; marigin-bottom: 0px; color: #777;'>Drop a file</h4>
-				<br>or</br>
-				<button class='btn'>Choose a file...</button>
-				<input class='manual' type='file'>
-				<$ } else { $>
-				<img src="<$!this.get("avatar")$>" />
-				<div class='remove'>
-					<a href='javascript:void(0);'>Remove</a>
+			<div class="avatar dropbox <$!this.get("avatar") != "" ? "filled" : "" $>">
+				<div class="status"></div>
+				<div class="inner">
+					<$ if(this.get("avatar") == "") { $>
+					<h4 style="padding-bottom: 0px; marigin-bottom: 0px; color: #777;"> Drop a file</h4>
+					<br />
+					<button class="btn">Choose a file...</button>
+					<input class="manual" type="file" />
+					<$ } else { $>
+					<$ if(/[\\w\\-]+\\.webm/i.test(this.get("avatar"))) { $>
+					<video src="<$!this.get("avatar")$>" autoplay muted loop />
+					<$ } else { $>
+					<img src="<$!this.get("avatar")$>" />
+					<$ } $>
+					<div class="remove">
+						<a href='javascript:void(0);'>Remove</a>
+					</div>
+					<$ } $>
 				</div>
-				<$ } $>
 			</div>
-		</div>
-		<div class='clear' style='height: 20px;'></div>
-		<p style='float: left;'>
-			<button class='btn dupedeck'>Duplicate Deck</button>
-		</p>
-		<$ if(this.id != "A778E120-672D-49D0-BAF8-8646DA3D3FAC") { $>
-		<p style='text-align: right;'>
-			<button class='btn btn-danger deletedeck'>Delete Deck</button>
-		</p>
-		<$ } $>
+			<div class="clear" style="height: 20px;"></div>
+			<p style="float: left;">
+				<button class="btn dupedeck">Duplicate Deck</button>
+			</p>
+			<$ if(this.id != "A778E120-672D-49D0-BAF8-8646DA3D3FAC") { $>
+			<p style="text-align: right;">
+				<button class="btn btn-danger deletedeck">Delete Deck</button>
+			</p>
+			<$ } $>
 		</div>
 	</script>
 	`;
 
 	d20plus.html.cardEditor = `
-	<script id='tmpl_cardeditor' type='text/html'>
-		<div class='dialog largedialog cardeditor' style='display: block;'>
-			<label>Name</label>
-			<input class='name' type='text'>
-			<div class='clear'></div>
+	<script id="tmpl_cardeditor" type="text/html">
+		<div class="dialog largedialog cardeditor" style="display: block;">
+			<h3 class="page_title text-capitalize">Name</h3>
+			<input class="name" type="text"></input>
+
+			<div class="card_tooltip w-100">
+				<div class="w-100 flex-wrap cardeditor__container cardeditor__tooltip-title">
+					<div class="flex-col">
+						<div class="cardeditor__header w-100">
+							<h3 class="page_title text-capitalize">Tooltip</h3>
+						</div>
+					</div>
+				</div>
+			</div>
+			<div class="cardeditor__row">
+				<div class="cardeditor__container">
+					<div class="d-flex">
+						<textarea class="card-tooltip" id="card-general-tooltip" type="text" maxlength="150"></textarea>
+					</div>
+				</div>
+			</div>
+			<br />
+			<small>
+				<span class="tooltip-count">0</span>
+				/150
+			</small>
+			<hr />
+
+			<div class="clear"></div>
 			<!-- BEGIN MOD -->
 			<button class='btn card-image-by-url' style="margin-bottom: 10px" data-card-id="<$!this.id$>">Set image from URL...</button>
 			<!-- END MOD -->
@@ -429,21 +471,83 @@ function initHTMLroll20EditorsMisc () {
 				<div class="status"></div>
 				<div class="inner">
 					<$ if(this.get("avatar") == "") { $>
-					<h4 style='padding-bottom: 0px; marigin-bottom: 0px; color: #777;'>Drop a file</h4>
-					<br>or</br>
-					<button class='btn'>Choose a file...</button>
-					<input class='manual' type='file'>
+					<h4 style="padding-bottom: 0px; marigin-bottom: 0px; color: #777;">Drop a file</h4>
+					<br />
+					<button class="btn">Choose a file...</button>
+					<input class="manual" type="file"></input>
+					<$ } else { $>
+					<$ if(/[\\w\\-]+\\.webm/i.test(this.get("avatar"))) { $>
+					<video src="<$!this.get("avatar")$>" autoplay muted loop />
 					<$ } else { $>
 					<img src="<$!this.get("avatar")$>" />
-					<div class='remove'>
+					<$ } $>
+					<div class="remove">
 						<a href='javascript:void(0);'>Remove</a>
 					</div>
 					<$ } $>
 				</div>
 			</div>
-			<div class='clear'></div>
+			<div class="clear" style="height: 15px;"></div>
+			<label>
+				<strong>Card Backing (Optional)</strong>
+			</label>
+			<div class="clear" style="height: 15px;"></div>
+			<!-- BEGIN MOD -->
+			<button class='btn card-backing-by-url' style="margin-bottom: 10px" data-card-id="<$!this.id$>">Set image from URL...</button>
+			<!-- END MOD -->
+			<div class="card_back dropbox <$! this.get("card_back") != "" ? "filled" : "" $>">
+				<div class="status"></div>
+				<div class="inner">
+					<$ if(this.get("card_back") == "") { $>
+					<h4 style="padding-bottom: 0px; marigin-bottom: 0px; color: #777;">Drop a file</h4>
+					<br />
+					<button class="btn">Choose a file...</button>
+					<input class="manual" type="file"></input>
+					<$ } else { $>
+					<$ if(/[\\w\\-]+\\.webm/i.test(this.get("card_back"))) { $>
+					<video src="<$!this.get("card_back")$>" autoplay muted loop />
+					<$ } else { $>
+					<img src="<$!this.get("card_back")$>" />
+					<$ } $>
+					<div class="remove">
+						<a href='javascript:void(0);'>Remove</a>
+					</div>
+					<$ } $>
+				</div>
+			</div>
+			<div class="clear"></div>
 			<label>&nbsp;</label>
-			<button class='deletecard btn btn-danger'>Delete Card</button>
+			<button class="deletecard btn btn-danger">Delete Card</button>
+		</div>
+	</script>
+	`;
+
+	d20plus.html.cardUploader = `
+	<script id="tmpl_cardupload" type="text/html">
+		<div class="dialog largedialog cardupload" style="display: block; height: 100%;">
+			<div class="row-fluid" style="height: calc(100% - 35px);">
+				<div class="span12" style="height: 100%;">
+					<div class="carduploader dropzone" style="border:2px dashed #88888888; position: relative; min-height: 100%;">
+						<div class="dz-message">
+							Drop image files here
+							<div class="dz-messagebox btn btn-primary">Or Click to Upload</div>
+							<em>By uploading, you affirm you have the rights to use each file.</em>
+						</div>
+					</div>
+					<div class="carduploader-converting" style="display: none;">
+						<p>Your files are being processed.</p>
+						<em>Waiting...</em>
+						<div class="carduploader_progress card-progress">
+							<div class="card-progress-bar card-progress-bar-striped card-progress-bar-animated" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" style="width: 0%"></div>
+						</div>
+					</div>
+				</div>
+			</div>
+			<!-- BEGIN MOD -->
+			<button class='btn deck-mass-cards-by-url' style='float: right; margin-left: 5px; margin-top: 5px;' data-deck-id="<$!this.id$>">
+				Add Cards from URLs
+			</button>
+			<!-- END MOD -->
 		</div>
 	</script>
 	`;

--- a/js/templates/template-roll20-page-settings.js
+++ b/js/templates/template-roll20-page-settings.js
@@ -84,9 +84,44 @@ function initHTMLPageSettings () {
 				<h3 class='page_title'>Background</h3>
 			</div>
 			<div class='pagedetails__subheader'>
-				<h4>Color</h4>
+				<div class='row'>
+					<div class='col-xs-5' style='display: flex; flex-direction: column; align-items: center; gap: 4px;'>
+						<div class='pagedetails__container'>
+							<h4>Board Color</h4>
+						</div>
+						<div class='pagedetails__container'>
+							<div>
+								<input class='pagebackground' type='text'>
+							</div>
+						</div>
+					</div>
+					<div class='col-xs-5' style='display: flex; flex-direction: column; align-items: center; gap: 4px;'>
+						<div class='pagedetails__container'>
+							<h4>Backdrop Color</h4>
+						</div>
+						<div class='pagedetails__container'>
+							<div>
+								<input class='wrappercolor' type='text'>
+							</div>
+						</div>
+					</div>
+				</div>
 			</div>
-			<input class='pagebackground' type='text'>
+			<div class='pagedetails__subheader'>
+				<div class='row'>
+					<div class='col-xs-7 pagedetails__subheader'>
+						<h4 class='text-capitalize'>Apply dominant color from map layer</h4>
+					</div>
+					<div class='col-xs-3 grid_switch'>
+						<label class='switch'>
+							<label class='sr-only' for='page-wrapper-color-from-map-toggle'>apply dominant color from map layer</label>
+							<input class='useautowrapper showtip' id='page-wrapper-color-from-map-toggle' title='Automatically update the backdrop to match the map layer' type='checkbox' value='1'>
+							<span class='slider round'></span>
+							</input>
+						</label>
+					</div>
+				</div>
+			</div>
 		</div>
 		<hr>
 		<!-- * SCALE */ -->
@@ -222,12 +257,14 @@ function initHTMLPageSettings () {
 						<div class='disable_box'>px</div>
 					</div>
 				</div>
-				<div class='pagedetails__subheader'>
-					<h4>Color</h4>
-				</div>
-				<div class='pagedetails__container'>
-					<div>
-						<input class='gridcolor' type='text'>
+				<div class='col' style='display: flex; flex-direction: column; gap: 4px;'>
+					<div class='pagedetails__subheader'>
+						<h4>Color</h4>
+					</div>
+					<div class='pagedetails__container'>
+						<div>
+							<input class='gridcolor' type='text'>
+						</div>
 					</div>
 				</div>
 				<div class='pagedetails__subheader'>


### PR DESCRIPTION
### Changelist

Fixed issues that appeared with recent roll20 update, and made some minor QoL changes related to those fixes:

- fixed DL features (give back pro to free users)
- fixed page options (grid etc.)
  - also restored the "auto bg color" functionality that was unavailable with better20
- fixed editor mode changes (switching between draw/select etc.)
  - horizontal toolbar now properly appears when selecting walls/doors etc.
- fixed deck and card editors
  - "add cards from url" button moved to the new roll20 "+add multiple" dialog
  - added "card backing from url" to card editor
  - added "delete" button to cards in deck editor
- fixed quick layers toolbar position (it appeared dislocated from main toolbar)
  - layers that are disabled in b20 config no longer show in the token right-click menu
  - quick layers toolbar position now respects actual r20 toolbar height and darkmode switch visibility


### Technical details

- rewritten `setMode()`
- reimplemented `renderAll()` 
- both methods are based on updated roll20 code
- kept old version of `setMode()` in case the `setModeRef()` becomes unavailable
- updated page editor, deck editor and card editor `html` to latest versions
- proper `defineProperty` hack with `return` statement
- added `isPro` feature just in case
- small changes to implement config check to layer selection in token menu
- added `handleCss` to .cfg module for proper QuickLayerButtons positioning
