### PR TITLE
Support windows and doors in Maps  import/export

### DIFF
--- a/dist/betteR20-core.user.js
+++ b/dist/betteR20-core.user.js
@@ -3681,8 +3681,6 @@ function baseToolModule () {
 										entry.graphics.forEach(it => map.thegraphics.create(it));
 										entry.paths.forEach(it => map.thepaths.create(it));
 										entry.text.forEach(it => map.thetexts.create(it));
-										entry.doors.forEach(it => map.doors.create(it));
-										entry.windows.forEach(it => map.windows.create(it));
 										map.save();
 										break;
 									}
@@ -3933,8 +3931,6 @@ function baseToolModule () {
 									graphics: (map.thegraphics || []).map(g => g.attributes),
 									text: (map.thetexts || []).map(t => t.attributes),
 									paths: (map.thepaths || []).map(p => p.attributes),
-                                    doors: (map.doors || []).map(d => d.attributes),
-                                    windows: (map.windows || []).map(w => w.attributes),
 								};
 							};
 

--- a/dist/betteR20-core.user.js
+++ b/dist/betteR20-core.user.js
@@ -3681,6 +3681,8 @@ function baseToolModule () {
 										entry.graphics.forEach(it => map.thegraphics.create(it));
 										entry.paths.forEach(it => map.thepaths.create(it));
 										entry.text.forEach(it => map.thetexts.create(it));
+										entry.doors.forEach(it => map.doors.create(it));
+										entry.windows.forEach(it => map.windows.create(it));
 										map.save();
 										break;
 									}
@@ -3931,6 +3933,8 @@ function baseToolModule () {
 									graphics: (map.thegraphics || []).map(g => g.attributes),
 									text: (map.thetexts || []).map(t => t.attributes),
 									paths: (map.thepaths || []).map(p => p.attributes),
+                                    doors: (map.doors || []).map(d => d.attributes),
+                                    windows: (map.windows || []).map(w => w.attributes),
 								};
 							};
 

--- a/js/base-tool-module.js
+++ b/js/base-tool-module.js
@@ -372,6 +372,8 @@ function baseToolModule () {
 										entry.graphics.forEach(it => map.thegraphics.create(it));
 										entry.paths.forEach(it => map.thepaths.create(it));
 										entry.text.forEach(it => map.thetexts.create(it));
+										entry.doors.forEach(it => map.doors.create(it));
+										entry.windows.forEach(it => map.windows.create(it));
 										map.save();
 										break;
 									}
@@ -622,6 +624,8 @@ function baseToolModule () {
 									graphics: (map.thegraphics || []).map(g => g.attributes),
 									text: (map.thetexts || []).map(t => t.attributes),
 									paths: (map.thepaths || []).map(p => p.attributes),
+                                    doors: (map.doors || []).map(d => d.attributes),
+                                    windows: (map.windows || []).map(w => w.attributes),
 								};
 							};
 


### PR DESCRIPTION
The windows and doors can be stored and loaded the same way as the other entries in the module export.